### PR TITLE
Determines tests that will be run

### DIFF
--- a/src/harness/tests_to_run.cfg
+++ b/src/harness/tests_to_run.cfg
@@ -1,0 +1,8 @@
+# Note: If TESTS_TO_RUN['run_all'] == True, then all tests are run, regardless
+# of the status of the flag on particular tests.
+
+TESTS_TO_RUN = {
+'run_all' : False,
+'afcs.sip.1' : True,
+'afcs.sip.2' : True
+}


### PR DESCRIPTION
This is created as a dictionary with flags set on individual tests. That way, the configuration file can contain all of the tests, and the user only need set individual tests to True or False. If this was set up as a list instead, the user would have to insert a potentially long list of tests, instead of the list of all possible tests, which can be pre-populated in a dictionary.

The file is being written as a python code snippet to be imported in, e.g., test_main.py, so it may be better to name it something like tests_to_run.py.