### PR TITLE
Test Harness Corrections from Sony

### DIFF
--- a/src/harness/afc.py
+++ b/src/harness/afc.py
@@ -49,7 +49,7 @@ class AfcImpl(afc_interface.AfcInterface):
     self._tls_config = TlsConfig()
 
   def SpectrumInquiry(self, request, ssl_cert=None, ssl_key=None):
-    return self._SpdRequest('availablespectruminquiryrequest', request, ssl_cert, ssl_key)
+    return self._SpdRequest('availableSpectrumInquiry', request, ssl_cert, ssl_key)
 
 
   def _SpdRequest(self, method_name, request, ssl_cert=None, ssl_key=None):

--- a/src/harness/request_validator.py
+++ b/src/harness/request_validator.py
@@ -301,7 +301,7 @@ def ellipse_is_valid(ellipse, log_file):
       is_valid = False
 
   if item_is_readable(ellipse, 'orientation', log_file):
-    if not type_is_correct(ellipse['orientation'], 'orientation', 'float',
+    if not type_is_correct(ellipse['orientation'], 'orientation', 'number',
                            log_file):
       is_valid = False
     elif ellipse['orientation'] < 0 or ellipse['orientation'] > 180:


### PR DESCRIPTION
Sho sent along the following feedback:

> We found two errors in Test Harness on the GitHub.
> 1.	Incorrect method name “availablespectruminquiryrequest” is used. It must be “availableSpectrumInquiry” according to the WFA SDI.
> 2.	The orientation field is restricted to floating-point value while the WFA SDI does not have such restriction.

These two items should be addressed in this pull request. I believe the change to address item 1 may also impact the request validation server that @w4je created.