### PR TITLE
Archive existing ULS snapshot and point to WFA snapshot

### DIFF
--- a/data/uls-snapshot/FCC ULS MW Snapshot 20210611 11AM EDT.zip
+++ b/data/uls-snapshot/FCC ULS MW Snapshot 20210611 11AM EDT.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3289f63dce28e73692fb951949446b4c1cb90197ce0e1cf2e8fc77df2f3ba58
-size 467526327

--- a/data/uls-snapshot/README.md
+++ b/data/uls-snapshot/README.md
@@ -1,0 +1,16 @@
+# ULS Snapshot Details
+## Snapshot source
+This repository uses a ULS Database weekly snapshot from the publically available Wi-Fi Alliance 6GHz-AFC repository.
+The current WInnForum approved snapshot version can be found here: https://github.com/Wi-FiTestSuite/6GHz-AFC/blob/baca971cf96fedfa6106d81345c862b0ed020cbb/ULS_database/FCC/weekly/l_micro_211024.zip
+
+## Notifications
+To receive notifications of when a new snapshot version is uploaded by the Wi-Fi Alliance, consider using a [file watcher service](https://app.github-file-watcher.com/) to monitor the [Wi-FiTestSuite/6GHz-AFC](https://github.com/Wi-FiTestSuite/6GHz-AFC) GitHub repository and ULS_Database/FCC/weekly/* subdirectory.
+
+## Archived Snapshots
+Previously approved versions of the database snapshot are listed below.
+
+### Archived Wi-Fi Alliance Snapshots
+* None
+
+### Archived WInnForum Snapshots
+1. [2021-06-11 11AM EDT - Pre WFA Sync](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/78b4771f0ae48ef8993060db2cf4794559372d45/data/uls-snapshot/FCC%20ULS%20MW%20Snapshot%2020210611%2011AM%20EDT.zip)


### PR DESCRIPTION
This request archives the existing WInnForum maintained ULS snapshot in favor of the Wi-Fi Alliance snapshot.

In place of the previous .zip file, a README file points users to the current (as of writing) version of the Wi-Fi Alliance snapshot.

- This link is specific to the current version, allowing WInnForum time to review any new versions uploaded by the Wi-Fi Alliance prior updating the README to point to the new version.
- The old WInnForum snapshot is still accessible via the archived snapshot section of the README.
- Instructions on how to receive notifications to any changes made by the Wi-Fi Alliance are included in the README.
  - I've tested the suggested file watch service on a separate repo, and it seems to work as expected, with some acceptable delay on notifications.

Some review may be needed for specific language in the README (e.g., "current WInnForum approved snapshot" in reference to linking to a specific version of the WFA snapshot).