### PR TITLE
Bug-fix: Incorrect method for recording skipped test in some cases

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -3,5 +3,6 @@
 harness/logs
 !harness/logs/README.md
 harness/responses/*.json
-# Temporarily suppress pushing inquiries while test vectors are under development
+# Temporarily suppress pushing inquiries and masks while test vectors are under development
 harness/inquiries/*.json
+harness/masks/*.json

--- a/src/harness/test_main.py
+++ b/src/harness/test_main.py
@@ -227,7 +227,7 @@ def main():
         else:
           logger.fatal('Request does not pass validation, but response mask doesn\'t expect an '
                        'error. Test SKIPPED.\n')
-          results.append(TestResult.SKIPPED)
+          results.add_result(test_name, TestResult.SKIPPED)
           continue
       else:
         logger.info('Request passes validation.')


### PR DESCRIPTION
If the inquiry was invalid but the response mask did not expect an error, we incorrectly used a now-removed method of adding the skipped test result from earlier in development. Updated to use the correct .add_result() method

Also adds temporary response_mask suppression to .gitignore