### PR TITLE
Add JSON versions of WFA test vector inquiries (v1.0)

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -3,6 +3,5 @@
 harness/logs
 !harness/logs/README.md
 harness/responses/*.json
-# Temporarily suppress pushing inquiries and masks while test vectors are under development
-harness/inquiries/*.json
+# Temporarily suppress pushing response masks while test vectors are under development
 harness/masks/*.json

--- a/src/harness/inquiries/AFCS.FSP.1.json
+++ b/src/harness/inquiries/AFCS.FSP.1.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP1",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP1",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP1"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.560614,
+            "latitude": 33.180621
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.10.json
+++ b/src/harness/inquiries/AFCS.FSP.10.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP10",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP10",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP10"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.636215,
+            "latitude": 41.879231
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.100.json
+++ b/src/harness/inquiries/AFCS.FSP.100.json
@@ -1,0 +1,418 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP1",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP1",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP1"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.560614,
+            "latitude": 33.180621
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    },
+    {
+      "requestId": "REQ-FSP2",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP2",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP2"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.546817,
+            "latitude": 33.177062
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    },
+    {
+      "requestId": "REQ-FSP3",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP3",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP3"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.560701,
+            "latitude": 33.180553
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    },
+    {
+      "requestId": "REQ-FSP4",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP4",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP4"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.636215,
+            "latitude": 41.879231
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    },
+    {
+      "requestId": "REQ-FSP5",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP5",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP5"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.635929,
+            "latitude": 41.878912
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    },
+    {
+      "requestId": "REQ-FSP6",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP6",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP6"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.635929,
+            "latitude": 41.878912
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    },
+    {
+      "requestId": "REQ-FSP7",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP7",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP7"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": -3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.560614,
+            "latitude": 33.180621
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.11.json
+++ b/src/harness/inquiries/AFCS.FSP.11.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP11",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP11",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP11"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.635929,
+            "latitude": 41.878912
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.12.json
+++ b/src/harness/inquiries/AFCS.FSP.12.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP12",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP12",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP12"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.635929,
+            "latitude": 41.878912
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.13.json
+++ b/src/harness/inquiries/AFCS.FSP.13.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP13",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP13",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP13"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.376295,
+            "latitude": 33.769641
+          },
+          "majorAxis": 50,
+          "minorAxis": 30,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.14.json
+++ b/src/harness/inquiries/AFCS.FSP.14.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP14",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP14",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP14"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.376872,
+            "latitude": 33.770381
+          },
+          "majorAxis": 50,
+          "minorAxis": 30,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.15.json
+++ b/src/harness/inquiries/AFCS.FSP.15.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP15",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP15",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP15"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.376872,
+            "latitude": 33.770381
+          },
+          "majorAxis": 50,
+          "minorAxis": 30,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.16.json
+++ b/src/harness/inquiries/AFCS.FSP.16.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP16",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP16",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP16"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.376295,
+            "latitude": 33.769641
+          },
+          "majorAxis": 50,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.17.json
+++ b/src/harness/inquiries/AFCS.FSP.17.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP17",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP17",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP17"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.375067,
+            "latitude": 33.772642
+          },
+          "majorAxis": 50,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.18.json
+++ b/src/harness/inquiries/AFCS.FSP.18.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP18",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP18",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP18"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.375067,
+            "latitude": 33.772642
+          },
+          "majorAxis": 50,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.19.json
+++ b/src/harness/inquiries/AFCS.FSP.19.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP19",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP19",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP19"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.376295,
+            "latitude": 33.769641
+          },
+          "majorAxis": 50,
+          "minorAxis": 30,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.2.json
+++ b/src/harness/inquiries/AFCS.FSP.2.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP2",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP2",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP2"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.546817,
+            "latitude": 33.177062
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.20.json
+++ b/src/harness/inquiries/AFCS.FSP.20.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP20",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP20",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP20"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.376872,
+            "latitude": 33.770381
+          },
+          "majorAxis": 50,
+          "minorAxis": 30,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.21.json
+++ b/src/harness/inquiries/AFCS.FSP.21.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP21",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP21",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP21"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.376872,
+            "latitude": 33.770381
+          },
+          "majorAxis": 50,
+          "minorAxis": 30,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.22.json
+++ b/src/harness/inquiries/AFCS.FSP.22.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP22",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP22",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP22"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.376295,
+            "latitude": 33.769641
+          },
+          "majorAxis": 50,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.23.json
+++ b/src/harness/inquiries/AFCS.FSP.23.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP23",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP23",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP23"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.375067,
+            "latitude": 33.772642
+          },
+          "majorAxis": 50,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.24.json
+++ b/src/harness/inquiries/AFCS.FSP.24.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP24",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP24",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP24"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.375067,
+            "latitude": 33.772642
+          },
+          "majorAxis": 50,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.25.json
+++ b/src/harness/inquiries/AFCS.FSP.25.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP25",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP25",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP25"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -102.230361,
+            "latitude": 30.571694
+          },
+          "majorAxis": 100,
+          "minorAxis": 100,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.26.json
+++ b/src/harness/inquiries/AFCS.FSP.26.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP26",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP26",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP26"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -102.234875,
+            "latitude": 30.573949
+          },
+          "majorAxis": 300,
+          "minorAxis": 300,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.27.json
+++ b/src/harness/inquiries/AFCS.FSP.27.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP27",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP27",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP27"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -101.103761,
+            "latitude": 30.086965
+          },
+          "majorAxis": 250,
+          "minorAxis": 250,
+          "orientation": 70.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.28.json
+++ b/src/harness/inquiries/AFCS.FSP.28.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP28",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP28",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP28"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -102.230361,
+            "latitude": 30.571694
+          },
+          "majorAxis": 100,
+          "minorAxis": 100,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.29.json
+++ b/src/harness/inquiries/AFCS.FSP.29.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP29",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP29",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP29"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -102.234875,
+            "latitude": 30.573949
+          },
+          "majorAxis": 300,
+          "minorAxis": 300,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.3.json
+++ b/src/harness/inquiries/AFCS.FSP.3.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP3",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP3",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP3"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.560701,
+            "latitude": 33.180553
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.30.json
+++ b/src/harness/inquiries/AFCS.FSP.30.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP30",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP30",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP30"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -101.103761,
+            "latitude": 30.086965
+          },
+          "majorAxis": 250,
+          "minorAxis": 250,
+          "orientation": 70.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.31.json
+++ b/src/harness/inquiries/AFCS.FSP.31.json
@@ -1,0 +1,75 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP31",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP31",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP31"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "linearPolygon": {
+          "outerBoundary": [
+            {
+              "longitude": -102.231406,
+              "latitude": 30.5725933
+            },
+            {
+              "longitude": -102.229316,
+              "latitude": 30.5725933
+            },
+            {
+              "longitude": -102.229316,
+              "latitude": 30.570795
+            },
+            {
+              "longitude": -102.231406,
+              "latitude": 30.570795
+            }
+          ]
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.32.json
+++ b/src/harness/inquiries/AFCS.FSP.32.json
@@ -1,0 +1,103 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP32",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP32",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP32"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "radialPolygon": {
+          "center": {
+            "longitude": -102.234875,
+            "latitude": 30.573949
+          },
+          "outerBoundary": [
+            {
+              "length": 300.0,
+              "angle": 0.0
+            },
+            {
+              "length": 300.0,
+              "angle": 36.0
+            },
+            {
+              "length": 300.0,
+              "angle": 72.0
+            },
+            {
+              "length": 300.0,
+              "angle": 108.0
+            },
+            {
+              "length": 300.0,
+              "angle": 144.0
+            },
+            {
+              "length": 300.0,
+              "angle": 180.0
+            },
+            {
+              "length": 300.0,
+              "angle": 216.0
+            },
+            {
+              "length": 300.0,
+              "angle": 252.0
+            },
+            {
+              "length": 300.0,
+              "angle": 288.0
+            },
+            {
+              "length": 300.0,
+              "angle": 324.0
+            }
+          ]
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.33.json
+++ b/src/harness/inquiries/AFCS.FSP.33.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP33",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP33",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP33"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -101.103761,
+            "latitude": 30.086965
+          },
+          "majorAxis": 250,
+          "minorAxis": 250,
+          "orientation": 70.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.34.json
+++ b/src/harness/inquiries/AFCS.FSP.34.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP34",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP34",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP34"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -102.230361,
+            "latitude": 30.571694
+          },
+          "majorAxis": 100,
+          "minorAxis": 100,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.35.json
+++ b/src/harness/inquiries/AFCS.FSP.35.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP35",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP35",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP35"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -102.234875,
+            "latitude": 30.573949
+          },
+          "majorAxis": 300,
+          "minorAxis": 300,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.36.json
+++ b/src/harness/inquiries/AFCS.FSP.36.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP36",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP36",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP36"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -101.103761,
+            "latitude": 30.086965
+          },
+          "majorAxis": 250,
+          "minorAxis": 250,
+          "orientation": 70.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.37.json
+++ b/src/harness/inquiries/AFCS.FSP.37.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP37",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP37",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP37"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 9.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.174086769162,
+            "latitude": 34.0517490391756
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.38.json
+++ b/src/harness/inquiries/AFCS.FSP.38.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP38",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP38",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP38"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 55.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -112.067148,
+            "latitude": 33.44493
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.39.json
+++ b/src/harness/inquiries/AFCS.FSP.39.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP39",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP39",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP39"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 7.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.037267,
+            "latitude": 33.867634
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.4.json
+++ b/src/harness/inquiries/AFCS.FSP.4.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP4",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP4",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP4"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.636215,
+            "latitude": 41.879231
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.40.json
+++ b/src/harness/inquiries/AFCS.FSP.40.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP40",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP40",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP40"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 89.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -111.969947953029,
+            "latitude": 33.4657921944995
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.41.json
+++ b/src/harness/inquiries/AFCS.FSP.41.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP41",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP41",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP41"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 9.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -117.134037,
+            "latitude": 32.780716
+          },
+          "majorAxis": 50,
+          "minorAxis": 30,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.42.json
+++ b/src/harness/inquiries/AFCS.FSP.42.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP42",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP42",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP42"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 8.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -117.139232,
+            "latitude": 32.773875
+          },
+          "majorAxis": 50,
+          "minorAxis": 30,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.43.json
+++ b/src/harness/inquiries/AFCS.FSP.43.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP43",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP43",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP43"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 83.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -105.018517,
+            "latitude": 39.792935
+          },
+          "majorAxis": 50,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.44.json
+++ b/src/harness/inquiries/AFCS.FSP.44.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP44",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP44",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP44"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 9.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.174086769162,
+            "latitude": 34.0517490391756
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.45.json
+++ b/src/harness/inquiries/AFCS.FSP.45.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP45",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP45",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP45"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 55.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -112.067148,
+            "latitude": 33.44493
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.46.json
+++ b/src/harness/inquiries/AFCS.FSP.46.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP46",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP46",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP46"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 7.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.037267,
+            "latitude": 33.867634
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.47.json
+++ b/src/harness/inquiries/AFCS.FSP.47.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP47",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP47",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP47"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 89.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -111.969947953029,
+            "latitude": 33.4657921944995
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.48.json
+++ b/src/harness/inquiries/AFCS.FSP.48.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP48",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP48",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP48"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 9.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -117.134037,
+            "latitude": 32.780716
+          },
+          "majorAxis": 50,
+          "minorAxis": 30,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.49.json
+++ b/src/harness/inquiries/AFCS.FSP.49.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP49",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP49",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP49"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 8.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -117.139232,
+            "latitude": 32.773875
+          },
+          "majorAxis": 50,
+          "minorAxis": 30,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.5.json
+++ b/src/harness/inquiries/AFCS.FSP.5.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP5",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP5",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP5"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.635929,
+            "latitude": 41.878912
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.50.json
+++ b/src/harness/inquiries/AFCS.FSP.50.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP50",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP50",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP50"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 83.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -105.018517,
+            "latitude": 39.792935
+          },
+          "majorAxis": 50,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.51.json
+++ b/src/harness/inquiries/AFCS.FSP.51.json
@@ -1,0 +1,80 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP51",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP51",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP51"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.609841,
+            "latitude": 41.892312
+          },
+          "majorAxis": 10,
+          "minorAxis": 5,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 6048,
+          "highFrequency": 6109
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131,
+          "channelCfi": [
+            21,
+            25,
+            29,
+            33
+          ]
+        },
+        {
+          "globalOperatingClass": 132,
+          "channelCfi": [
+            19,
+            27,
+            35
+          ]
+        },
+        {
+          "globalOperatingClass": 133,
+          "channelCfi": [
+            23,
+            39
+          ]
+        },
+        {
+          "globalOperatingClass": 134,
+          "channelCfi": [
+            15,
+            47
+          ]
+        },
+        {
+          "globalOperatingClass": 136,
+          "channelCfi": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.52.json
+++ b/src/harness/inquiries/AFCS.FSP.52.json
@@ -1,0 +1,80 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP52",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP52",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP52"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.609841,
+            "latitude": 41.892312
+          },
+          "majorAxis": 10,
+          "minorAxis": 5,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 6048,
+          "highFrequency": 6109
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131,
+          "channelCfi": [
+            21,
+            25,
+            29,
+            33
+          ]
+        },
+        {
+          "globalOperatingClass": 132,
+          "channelCfi": [
+            19,
+            27,
+            35
+          ]
+        },
+        {
+          "globalOperatingClass": 133,
+          "channelCfi": [
+            23,
+            39
+          ]
+        },
+        {
+          "globalOperatingClass": 134,
+          "channelCfi": [
+            15,
+            47
+          ]
+        },
+        {
+          "globalOperatingClass": 136,
+          "channelCfi": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.53.json
+++ b/src/harness/inquiries/AFCS.FSP.53.json
@@ -1,0 +1,76 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP53",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP53",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP53"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -83.053009,
+            "latitude": 42.333582
+          },
+          "majorAxis": 5,
+          "minorAxis": 5,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 6360,
+          "highFrequency": 6391
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131,
+          "channelCfi": [
+            81,
+            85,
+            89
+          ]
+        },
+        {
+          "globalOperatingClass": 132,
+          "channelCfi": [
+            83,
+            91
+          ]
+        },
+        {
+          "globalOperatingClass": 133,
+          "channelCfi": [
+            87
+          ]
+        },
+        {
+          "globalOperatingClass": 134,
+          "channelCfi": [
+            79
+          ]
+        },
+        {
+          "globalOperatingClass": 136,
+          "channelCfi": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.54.json
+++ b/src/harness/inquiries/AFCS.FSP.54.json
@@ -1,0 +1,76 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP54",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP54",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP54"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -83.053009,
+            "latitude": 42.333582
+          },
+          "majorAxis": 5,
+          "minorAxis": 5,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 6360,
+          "highFrequency": 6391
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131,
+          "channelCfi": [
+            81,
+            85,
+            89
+          ]
+        },
+        {
+          "globalOperatingClass": 132,
+          "channelCfi": [
+            83,
+            91
+          ]
+        },
+        {
+          "globalOperatingClass": 133,
+          "channelCfi": [
+            87
+          ]
+        },
+        {
+          "globalOperatingClass": 134,
+          "channelCfi": [
+            79
+          ]
+        },
+        {
+          "globalOperatingClass": 136,
+          "channelCfi": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.55.json
+++ b/src/harness/inquiries/AFCS.FSP.55.json
@@ -1,0 +1,79 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP55",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP55",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP55"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -76.606187,
+            "latitude": 39.286173
+          },
+          "majorAxis": 10,
+          "minorAxis": 5,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 6019,
+          "highFrequency": 6079
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131,
+          "channelCfi": [
+            13,
+            17,
+            21,
+            25
+          ]
+        },
+        {
+          "globalOperatingClass": 132,
+          "channelCfi": [
+            11,
+            19,
+            27
+          ]
+        },
+        {
+          "globalOperatingClass": 133,
+          "channelCfi": [
+            7,
+            23
+          ]
+        },
+        {
+          "globalOperatingClass": 134,
+          "channelCfi": [
+            15
+          ]
+        },
+        {
+          "globalOperatingClass": 136,
+          "channelCfi": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.56.json
+++ b/src/harness/inquiries/AFCS.FSP.56.json
@@ -1,0 +1,79 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP56",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP56",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP56"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -76.606187,
+            "latitude": 39.286173
+          },
+          "majorAxis": 10,
+          "minorAxis": 5,
+          "orientation": 10.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 6019,
+          "highFrequency": 6079
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131,
+          "channelCfi": [
+            13,
+            17,
+            21,
+            25
+          ]
+        },
+        {
+          "globalOperatingClass": 132,
+          "channelCfi": [
+            11,
+            19,
+            27
+          ]
+        },
+        {
+          "globalOperatingClass": 133,
+          "channelCfi": [
+            7,
+            23
+          ]
+        },
+        {
+          "globalOperatingClass": 134,
+          "channelCfi": [
+            15
+          ]
+        },
+        {
+          "globalOperatingClass": 136,
+          "channelCfi": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.57.json
+++ b/src/harness/inquiries/AFCS.FSP.57.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP57",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP57",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP57"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -152.0359,
+            "latitude": 61.068
+          },
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.58.json
+++ b/src/harness/inquiries/AFCS.FSP.58.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP58",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP58",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP58"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -149.3355,
+            "latitude": 64.203
+          },
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.59.json
+++ b/src/harness/inquiries/AFCS.FSP.59.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP59",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP59",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP59"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -148.899575,
+            "latitude": 69.154632
+          },
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.6.json
+++ b/src/harness/inquiries/AFCS.FSP.6.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP6",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP6",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP6"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.635929,
+            "latitude": 41.878912
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.60.json
+++ b/src/harness/inquiries/AFCS.FSP.60.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP60",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP60",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP60"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -149.63919,
+            "latitude": 70.328691
+          },
+          "majorAxis": 25,
+          "minorAxis": 25,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.61.json
+++ b/src/harness/inquiries/AFCS.FSP.61.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP61",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP61",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP61"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -149.637287,
+            "latitude": 70.328372
+          },
+          "majorAxis": 25,
+          "minorAxis": 25,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.62.json
+++ b/src/harness/inquiries/AFCS.FSP.62.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP62",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP62",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP62"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -120.68475,
+            "latitude": 38.823357
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.63.json
+++ b/src/harness/inquiries/AFCS.FSP.63.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP63",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP63",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP63"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -120.68426,
+            "latitude": 38.820129
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.64.json
+++ b/src/harness/inquiries/AFCS.FSP.64.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP64",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP64",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP64"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -120.695567,
+            "latitude": 38.816705
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.65.json
+++ b/src/harness/inquiries/AFCS.FSP.65.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP65",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP65",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP65"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -120.68475,
+            "latitude": 38.823357
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.66.json
+++ b/src/harness/inquiries/AFCS.FSP.66.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP66",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP66",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP66"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -120.68426,
+            "latitude": 38.820129
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.67.json
+++ b/src/harness/inquiries/AFCS.FSP.67.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP67",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP67",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP67"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -120.695567,
+            "latitude": 38.816705
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.68.json
+++ b/src/harness/inquiries/AFCS.FSP.68.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP68",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP68",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP68"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -120.68475,
+            "latitude": 38.823357
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.69.json
+++ b/src/harness/inquiries/AFCS.FSP.69.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP69",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP69",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP69"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -120.68426,
+            "latitude": 38.820129
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.7.json
+++ b/src/harness/inquiries/AFCS.FSP.7.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP7",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP7",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP7"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": -3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.560614,
+            "latitude": 33.180621
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.70.json
+++ b/src/harness/inquiries/AFCS.FSP.70.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP70",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP70",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP70"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -120.695567,
+            "latitude": 38.816705
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.71.json
+++ b/src/harness/inquiries/AFCS.FSP.71.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP71",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP71",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP71"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -116.42293,
+            "latitude": 41.095169
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.72.json
+++ b/src/harness/inquiries/AFCS.FSP.72.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP72",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP72",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP72"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -116.421737,
+            "latitude": 41.073958
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.73.json
+++ b/src/harness/inquiries/AFCS.FSP.73.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP73",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP73",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP73"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -116.42293,
+            "latitude": 41.095169
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.74.json
+++ b/src/harness/inquiries/AFCS.FSP.74.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP74",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP74",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP74"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -116.421737,
+            "latitude": 41.073958
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.75.json
+++ b/src/harness/inquiries/AFCS.FSP.75.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP75",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP75",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP75"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -116.42293,
+            "latitude": 41.095169
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.76.json
+++ b/src/harness/inquiries/AFCS.FSP.76.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP76",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP76",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP76"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -116.421737,
+            "latitude": 41.073958
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.77.json
+++ b/src/harness/inquiries/AFCS.FSP.77.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP77",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP77",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP77"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.300259,
+            "latitude": 39.523761
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.78.json
+++ b/src/harness/inquiries/AFCS.FSP.78.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP78",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP78",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP78"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.275352,
+            "latitude": 39.519614
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.79.json
+++ b/src/harness/inquiries/AFCS.FSP.79.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP79",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP79",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP79"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.300259,
+            "latitude": 39.523761
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.8.json
+++ b/src/harness/inquiries/AFCS.FSP.8.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP8",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP8",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP8"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.546817,
+            "latitude": 33.177062
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.80.json
+++ b/src/harness/inquiries/AFCS.FSP.80.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP80",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP80",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP80"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.301513,
+            "latitude": 39.51883
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.81.json
+++ b/src/harness/inquiries/AFCS.FSP.81.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP81",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP81",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP81"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.275352,
+            "latitude": 39.519614
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.82.json
+++ b/src/harness/inquiries/AFCS.FSP.82.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP82",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP82",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP82"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.300259,
+            "latitude": 39.523761
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.83.json
+++ b/src/harness/inquiries/AFCS.FSP.83.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP83",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP83",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP83"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.301513,
+            "latitude": 39.51883
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.84.json
+++ b/src/harness/inquiries/AFCS.FSP.84.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP84",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP84",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP84"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.275352,
+            "latitude": 39.519614
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.85.json
+++ b/src/harness/inquiries/AFCS.FSP.85.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP85",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP85",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP85"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -76.483668,
+            "latitude": 41.684652
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.86.json
+++ b/src/harness/inquiries/AFCS.FSP.86.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP86",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP86",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP86"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -76.473996,
+            "latitude": 41.711802
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.87.json
+++ b/src/harness/inquiries/AFCS.FSP.87.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP87",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP87",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP87"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -76.482183,
+            "latitude": 41.681608
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.88.json
+++ b/src/harness/inquiries/AFCS.FSP.88.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP88",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP88",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP88"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -76.483668,
+            "latitude": 41.684652
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.89.json
+++ b/src/harness/inquiries/AFCS.FSP.89.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP89",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP89",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP89"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -76.473996,
+            "latitude": 41.711802
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.9.json
+++ b/src/harness/inquiries/AFCS.FSP.9.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP9",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP9",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP9"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.560701,
+            "latitude": 33.180553
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.90.json
+++ b/src/harness/inquiries/AFCS.FSP.90.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP90",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP90",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP90"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -76.482183,
+            "latitude": 41.681608
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.91.json
+++ b/src/harness/inquiries/AFCS.FSP.91.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP91",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP91",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP91"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -76.483668,
+            "latitude": 41.684652
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.92.json
+++ b/src/harness/inquiries/AFCS.FSP.92.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP92",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP92",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP92"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -76.473996,
+            "latitude": 41.711802
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.93.json
+++ b/src/harness/inquiries/AFCS.FSP.93.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP93",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP93",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP93"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -122.327159,
+            "latitude": 47.608377
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.94.json
+++ b/src/harness/inquiries/AFCS.FSP.94.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP94",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP94",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP94"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -122.327159,
+            "latitude": 47.608377
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 1
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.95.json
+++ b/src/harness/inquiries/AFCS.FSP.95.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP95",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP95",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP95"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -122.327159,
+            "latitude": 47.608377
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.96.json
+++ b/src/harness/inquiries/AFCS.FSP.96.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP96",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP96",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP96"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 100.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 10
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -122.327159,
+            "latitude": 47.608377
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.97.json
+++ b/src/harness/inquiries/AFCS.FSP.97.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP97",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP97",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP97"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -122.327159,
+            "latitude": 47.608377
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.98.json
+++ b/src/harness/inquiries/AFCS.FSP.98.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP98",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP98",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP98"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 18.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.088367,
+            "latitude": 47.747233
+          },
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.FSP.99.json
+++ b/src/harness/inquiries/AFCS.FSP.99.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-FSP99",
+      "deviceDescriptor": {
+        "serialNumber": "SN-FSP99",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-FSP99"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.077035,
+            "latitude": 47.741269
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.IBP.1.json
+++ b/src/harness/inquiries/AFCS.IBP.1.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-IBP1",
+      "deviceDescriptor": {
+        "serialNumber": "SN-IBP1",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-IBP1"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -84.331771,
+            "latitude": 46.596068
+          },
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.IBP.2.json
+++ b/src/harness/inquiries/AFCS.IBP.2.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-IBP2",
+      "deviceDescriptor": {
+        "serialNumber": "SN-IBP2",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-IBP2"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -92.155281,
+            "latitude": 48.359797
+          },
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.IBP.3.json
+++ b/src/harness/inquiries/AFCS.IBP.3.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-IBP3",
+      "deviceDescriptor": {
+        "serialNumber": "SN-IBP3",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-IBP3"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -130.838902,
+            "latitude": 54.90827
+          },
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.IBP.4.json
+++ b/src/harness/inquiries/AFCS.IBP.4.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-IBP4",
+      "deviceDescriptor": {
+        "serialNumber": "SN-IBP4",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-IBP4"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -83.054659,
+            "latitude": 42.32452
+          },
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.IBP.5.json
+++ b/src/harness/inquiries/AFCS.IBP.5.json
@@ -1,0 +1,60 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-IBP5",
+      "deviceDescriptor": {
+        "serialNumber": "SN-IBP5",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-IBP5"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.IBP.6.json
+++ b/src/harness/inquiries/AFCS.IBP.6.json
@@ -1,0 +1,60 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-IBP6",
+      "deviceDescriptor": {
+        "serialNumber": "SN-IBP6",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-IBP6"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.IBP.7.json
+++ b/src/harness/inquiries/AFCS.IBP.7.json
@@ -1,0 +1,60 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-IBP7",
+      "deviceDescriptor": {
+        "serialNumber": "SN-IBP7",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-IBP7"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.IBP.8.json
+++ b/src/harness/inquiries/AFCS.IBP.8.json
@@ -1,0 +1,60 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-IBP8",
+      "deviceDescriptor": {
+        "serialNumber": "SN-IBP8",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-IBP8"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 3
+        },
+        "ellipse": {
+          "majorAxis": 30,
+          "minorAxis": 30,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 2
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.1.json
+++ b/src/harness/inquiries/AFCS.SIP.1.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP1",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP1",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP1"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 10.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -66.722083,
+            "latitude": 18.16277
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.10.json
+++ b/src/harness/inquiries/AFCS.SIP.10.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP10",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP10",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP10"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 8.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -91.432634,
+            "latitude": 41.486251
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.11.json
+++ b/src/harness/inquiries/AFCS.SIP.11.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP11",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP11",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP11"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 11.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.014402,
+            "latitude": 37.006164
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.12.json
+++ b/src/harness/inquiries/AFCS.SIP.12.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP12",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP12",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP12"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 12.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -108.385163,
+            "latitude": 34.282091
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.13.json
+++ b/src/harness/inquiries/AFCS.SIP.13.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP13",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP13",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP13"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 6.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -64.864822,
+            "latitude": 17.69417
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.14.json
+++ b/src/harness/inquiries/AFCS.SIP.14.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP14",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP14",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP14"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.95,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -117.959636,
+            "latitude": 37.402836
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.15.json
+++ b/src/harness/inquiries/AFCS.SIP.15.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP15",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP15",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP15"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 15.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -121.268964,
+            "latitude": 40.641732
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.2.json
+++ b/src/harness/inquiries/AFCS.SIP.2.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP2",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP2",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP2"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 300.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 30
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -78.468021,
+            "latitude": 38.377266
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.3.json
+++ b/src/harness/inquiries/AFCS.SIP.3.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP3",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP3",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP3"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 12.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -107.388916,
+            "latitude": 33.8291
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.4.json
+++ b/src/harness/inquiries/AFCS.SIP.4.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP4",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP4",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP4"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 18.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -119.585033,
+            "latitude": 48.361254
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.5.json
+++ b/src/harness/inquiries/AFCS.SIP.5.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP5",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP5",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP5"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 78.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 8
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -103.669369,
+            "latitude": 30.351048
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.6.json
+++ b/src/harness/inquiries/AFCS.SIP.6.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP6",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP6",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP6"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 45.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 5
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -71.675651,
+            "latitude": 43.256237
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.7.json
+++ b/src/harness/inquiries/AFCS.SIP.7.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP7",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP7",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP7"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 6.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -111.304475,
+            "latitude": 31.914955
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.8.json
+++ b/src/harness/inquiries/AFCS.SIP.8.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP8",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP8",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP8"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 8.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -106.377759,
+            "latitude": 35.507881
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SIP.9.json
+++ b/src/harness/inquiries/AFCS.SIP.9.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SIP9",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SIP9",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SIP9"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 15.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -155.122522,
+            "latitude": 19.705507
+          },
+          "majorAxis": 150,
+          "minorAxis": 150,
+          "orientation": 0.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.SRS.1.json
+++ b/src/harness/inquiries/AFCS.SRS.1.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-SRS1",
+      "deviceDescriptor": {
+        "serialNumber": "SN-SRS1",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-SRS1"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -97.560614,
+            "latitude": 33.180621
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.URS.1.json
+++ b/src/harness/inquiries/AFCS.URS.1.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-URS1",
+      "deviceDescriptor": {
+        "serialNumber": "SN-URS1",
+        "certificationId": [
+          {
+            "nra": "FCC"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -118.255078,
+            "latitude": 34.051151
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.URS.2.json
+++ b/src/harness/inquiries/AFCS.URS.2.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-URS2",
+      "deviceDescriptor": {
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-URS2"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -87.683357,
+            "latitude": 41.723655
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.URS.3.json
+++ b/src/harness/inquiries/AFCS.URS.3.json
@@ -1,0 +1,60 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-URS3",
+      "deviceDescriptor": {
+        "serialNumber": "SN-URS3",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-URS3"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.URS.4.json
+++ b/src/harness/inquiries/AFCS.URS.4.json
@@ -1,0 +1,61 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-URS4",
+      "deviceDescriptor": {
+        "serialNumber": "SN-URS4",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-URS4"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -95.36454,
+            "latitude": 29.75077
+          }
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.URS.5.json
+++ b/src/harness/inquiries/AFCS.URS.5.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-URS5",
+      "deviceDescriptor": {
+        "serialNumber": "SN-URS5",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-URS5"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -75.161307,
+            "latitude": 39.949079
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.URS.6.json
+++ b/src/harness/inquiries/AFCS.URS.6.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-URS6",
+      "deviceDescriptor": {
+        "serialNumber": "SN-URS6",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-URS6"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL"
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -112.081081,
+            "latitude": 33.449081
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}

--- a/src/harness/inquiries/AFCS.URS.7.json
+++ b/src/harness/inquiries/AFCS.URS.7.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.3",
+  "availableSpectrumInquiryRequests": [
+    {
+      "requestId": "REQ-URS7",
+      "deviceDescriptor": {
+        "serialNumber": "SN-URS7",
+        "certificationId": [
+          {
+            "nra": "FCC",
+            "id": "FCCID-URS7"
+          }
+        ],
+        "rulesetIds": [
+          "US_47_CFR_PART_15_SUBPART_E"
+        ]
+      },
+      "location": {
+        "elevation": {
+          "height": 3.0,
+          "heightType": "AGL",
+          "verticalUncertainty": 2
+        },
+        "ellipse": {
+          "center": {
+            "longitude": -57.85685,
+            "latitude": -51.692741
+          },
+          "majorAxis": 100,
+          "minorAxis": 50,
+          "orientation": 45.0
+        },
+        "indoorDeployment": 0
+      },
+      "inquiredFrequencyRange": [
+        {
+          "lowFrequency": 5925,
+          "highFrequency": 6425
+        },
+        {
+          "lowFrequency": 6525,
+          "highFrequency": 6875
+        }
+      ],
+      "inquiredChannels": [
+        {
+          "globalOperatingClass": 131
+        },
+        {
+          "globalOperatingClass": 132
+        },
+        {
+          "globalOperatingClass": 133
+        },
+        {
+          "globalOperatingClass": 134
+        },
+        {
+          "globalOperatingClass": 136
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds JSON versions of the inquiry requests defined in v1.0 of the WFA AFC SUT test vector spreadsheet. The most recent version of the inquiry spreadsheet is available from the WFA under "AFC Specification and Test Plans" at: https://www.wi-fi.org/discover-wi-fi/specifications

Note that inquiry files are included for AFCS.IBP.{5-8} using the current (incomplete) definitions. These requests do not pass validation and will be skipped by the test harness.