### PR TITLE
Update validation, terminology to current specifications (SDI v1.3.2, SUT Plan v1.3)

### DIFF
--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -36,7 +36,7 @@ Harness configuration files are located in `./cfg`. Detailed descriptions of eac
     *   By default, the `{inquiries_dir}` directory is `./inquiries` and the `{masks_dir}` directory is `./masks`.
 
 ## Specification version
-AFC communication and message validation is performed according to the current version of the Wi-Fi Alliance AFC System to AFC Device Interface Specification (v1.3.2). This specification is available from the [Wi-Fi Alliance website](https://www.wi-fi.org/discover-wi-fi/specifications) under "AFC Specification and Test Plans."
+AFC communication and message validation is performed according to the current version of the Wi-Fi Alliance AFC System to AFC Device Interface Specification (v1.3.2). Tests are executed and evaluated according to the current version fo the Wi-Fi Alliance AFC System Under Test (SUT) Compliance Test Plan (v1.3). These specifications are available from the [Wi-Fi Alliance website](https://www.wi-fi.org/discover-wi-fi/specifications) under "AFC Specification and Test Plans."
 
 ## Sample files
 Example json files for the inquiry request, response, and response mask are provided as:
@@ -46,7 +46,7 @@ Example json files for the inquiry request, response, and response mask are prov
 
 ## Harness output
 *   **Console output**
-    *   Validation warnings, mask violations, test errors, and summary of test results (passed/failed/skipped)
+    *   Validation warnings, mask violations, test errors, and summary of test results (expected/unexpected/skipped)
 *   **{logs_dir}/harness_main.log**
     *   All harness output, including ingested requests, responses, and response masks (overwritten each time `./test_main.py` is executed)
     *   By default, `logs_dir` is `./logs`

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -36,7 +36,7 @@ Harness configuration files are located in `./cfg`. Detailed descriptions of eac
     *   By default, the `{inquiries_dir}` directory is `./inquiries` and the `{masks_dir}` directory is `./masks`.
 
 ## Specification version
-AFC communication and message validation is performed according to the current version of the Wi-Fi Alliance AFC System to AFC Device Interface Specification (v1.3). This specification is available from the [Wi-Fi Alliance website](https://www.wi-fi.org/discover-wi-fi/specifications) under "AFC Specification and Test Plans."
+AFC communication and message validation is performed according to the current version of the Wi-Fi Alliance AFC System to AFC Device Interface Specification (v1.3.2). This specification is available from the [Wi-Fi Alliance website](https://www.wi-fi.org/discover-wi-fi/specifications) under "AFC Specification and Test Plans."
 
 ## Sample files
 Example json files for the inquiry request, response, and response mask are provided as:

--- a/src/harness/available_spectrum_inquiry_response.py
+++ b/src/harness/available_spectrum_inquiry_response.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""Available Spectrum Inquiry Response Definitions - SDI v1.3"""
+"""Available Spectrum Inquiry Response Definitions - SDI v1.3.2"""
 
 import enum
 import json

--- a/src/harness/expected_inquiry_response.py
+++ b/src/harness/expected_inquiry_response.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""Expected Available Spectrum Inquiry Response Definitions - SDI v1.3"""
+"""Expected Available Spectrum Inquiry Response Definitions - SDI v1.3.2"""
 
 from dataclasses import dataclass
 from contextlib import suppress

--- a/src/harness/interface_common.py
+++ b/src/harness/interface_common.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC System to AFC Device Interface Common Classes - SDI v1.3"""
+"""AFC System to AFC Device Interface Common Classes - SDI v1.3.2"""
 
 from dataclasses import dataclass
 from typing import Any
@@ -21,7 +21,7 @@ class FrequencyRange:
   """Frequency Range specification for spectrum availability requests and responses
 
   Ranges run from lowFrequency (inclusive) up to but not including highFrequency,
-  that is: the range [lowFrequency, highFrequency). Current SDI spec (v1.3) does not specify
+  that is: the range [lowFrequency, highFrequency). Current SDI spec (v1.3.2) does not specify
   this interpretation, but it is implied by the spec's sample_response (contiguous frequency
   ranges sharing a high/low freq value)
 

--- a/src/harness/request_validator.py
+++ b/src/harness/request_validator.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-"""AFC Spectrum Inquiry Request Validation - SDI v1.3
+"""AFC Spectrum Inquiry Request Validation - SDI v1.3.2
 
 Validates a text file containing a spectrum inquiry request in the WFA
 standard format. Checks:

--- a/src/harness/response_mask_runner.py
+++ b/src/harness/response_mask_runner.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC Spectrum Inquiry Response Mask Runner - SDI v1.3
+"""AFC Spectrum Inquiry Response Mask Runner - SDI v1.3.2
 
 Mask runner functions will compare the provided response mask to a received response
 and provide a pass/fail result, logging results along the way. Comparison is performed

--- a/src/harness/response_mask_validator.py
+++ b/src/harness/response_mask_validator.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC Spectrum Inquiry Expected Response Validation - SDI v1.3
+"""AFC Spectrum Inquiry Expected Response Validation - SDI v1.3.2
 
 Validation functions will exhaustively test all fields (i.e.,
 validation does not stop on the first failure, but will report all

--- a/src/harness/response_validator.py
+++ b/src/harness/response_validator.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC Spectrum Inquiry Response Validation - SDI v1.3
+"""AFC Spectrum Inquiry Response Validation - SDI v1.3.2
 
 Validation functions will exhaustively test all fields (i.e.,
 validation does not stop on the first failure, but will report all

--- a/src/harness/sdi_validator_common.py
+++ b/src/harness/sdi_validator_common.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC Common SDI Validation - SDI v1.3
+"""AFC Common SDI Validation - SDI v1.3.2
 
 Validation functions will exhaustively test all fields (i.e.,
 validation does not stop on the first failure, but will report all
@@ -167,28 +167,18 @@ class SDIValidatorBase(TestHarnessLogger):
     """Validates a version string
 
     Checks:
-      version must be of format n.m where n and m are non-negative integers
+      None (format requirement removed in SDI v1.3.1)
 
     Parameters:
       version (string): version string to be validated
 
     Returns:
-      True if version string is valid
-      False otherwise"""
-    is_valid = True
-    try:
-      if re.match("\\A[0-9]+\\.[0-9]+\\Z", version) is None:
-        is_valid = False
-        self._warning(f'Invalid version string format: {version}')
-    except TypeError:
-      is_valid = False
-      self._warning(f'Could not parse version string: {version}')
-
-    if is_valid and version not in self._supported_versions:
+      True always (warns if version not in supported list)"""
+    if version not in self._supported_versions:
       self._warning(f'Message version ({version}) is not in list of supported versions '
                     f'({self._supported_versions}). Errors in validation and comparison may '
                      'result.')
-    return is_valid
+    return True
 
   def validate_vendor_extension_list(self, exts: List[VendorExtension]):
     """Dispatches list of extensions to validate_vendor_extension


### PR DESCRIPTION
This PR resolves #22 and resolves #23 by removing the "n.m" format check from the version string validation and updating the terminology to use expected/unexpected instead of pass/fail for test results.

Message validation still referred to as pass fail (output messages now specify SDI validation explicitly).
"Test skipped" still used to describe situations where an expected/unexpected result could not be reached because of an issue with the test.