### PR TITLE
Allow placeholder channel availability objects, fix channel info short-circuit

### DIFF
--- a/src/harness/response_validator.py
+++ b/src/harness/response_validator.py
@@ -136,7 +136,6 @@ class InquiryResponseValidator(sdi_validate.SDIValidatorBase):
 
     Checks:
       channelCfi and maxEirp must have equal lengths
-      channelCfi and maxEirp cannot be empty
       All values for channelCfi, maxEirp and globalOperatingClass must be valid, finite numbers
 
     Parameters:
@@ -152,12 +151,6 @@ class InquiryResponseValidator(sdi_validate.SDIValidatorBase):
         is_valid = False
         self._warning(f'Length of channelCfi list ({info.channelCfi}) does '
                       f'not match length of maxEirp list ({info.maxEirp})')
-
-      # channelCfi and maxEirp cannot be empty
-      for field in ['channelCfi', 'maxEirp']:
-        if len(getattr(info, field)) < 1:
-          is_valid = False
-          self._warning(f'Length of {field} list must be at least 1')
     except TypeError as ex:
       is_valid = False
       self._warning(f'Could not validate lengths of channel and eirp lists: {ex}')


### PR DESCRIPTION
Resolves #21 and fixes a short-circuit bug in comparing response/mask channel info (Test would unintentionally skip remaining GOC or GOC/CFI pairs after encountering a GOC or GOC/CFI pair that was not in the mask).

Adds support for "placeholder" channel availability objects for a globalOperatingClass (i.e., objects with a specified GOC but empty arrays for channelCfi and maxEirp) in both responses and response masks.

Mask runner code treats absence of an availability object for a GOC the same as a placeholder GOC.

This leads to potentially unexpected behavior if the response mask contains a placeholder and a non-placeholder object for the same GOC value and object validation is not enforced when executing a test. Objects with duplicate GOCs are disallowed in the mask by the mask validator, even if each GOC object has non-overlapping channelCfi entries (i.e., could be merged into a single object with no conflicts). If the test is executed without validation, two or more non-placeholder GOC objects will raise a ValueError, as before. However, as a result of these changes, a non-placeholder and placeholder object with the same GOC value will not raise a ValueError, and the test will proceed as though the placeholder object does not exist. As the root-level test_main script enforces validation, this behavior will not arise in normal use; however, users adapting the underlying validator or test runner modules may need to consider this behavior.

Note: the harness places no restrictions on duplicate GOCs or GOC/CFI pairs in responses. In the event of duplicates, all GOC/CFI pairs will be compared against the relevant mask entry. This behavior remains unchanged.