### PR TITLE
Improve warning messages on object conversion failure

### DIFF
--- a/src/harness/sdi_validator_common.py
+++ b/src/harness/sdi_validator_common.py
@@ -53,7 +53,8 @@ def common_sdi_validator(specific_logic):
       is_valid = args[0].validate_types(validation_target)
       is_valid &= specific_logic(args[0], validation_target)
       return is_valid
-    args[0]._warning('Failed to validate dataclass representation')
+    args[0]._warning(f'Unable to use object as {target_class} for validation. '
+                     f'Subsequent use of this object will likely fail: {args[1]}')
     return False
   return wrapper
 
@@ -84,7 +85,7 @@ class SDIValidatorBase(TestHarnessLogger):
       try:
         conv_obj = target_type(**src_obj)
       except TypeError as err:
-        self._warning(f'Exception converting from obj dict: {err}')
+        self._warning(f'Exception converting from dict to {target_type}: {err}')
     elif isinstance(src_obj, target_type):
       conv_obj = src_obj
     else:


### PR DESCRIPTION
Resolves #18 by clarifying messages related to dataclass conversion in validator paths. This PR does not use either of the methods proposed in #18 for reasons discussed below:

- > Selective removal of the suppress(Error) wrappers for "critical" sub-fields would allow the error to propagate upwards and trigger the except clause in test_main.py. However, this would also prevent the partial initialization of any parent object, which is not desired by other code (i.e., the validators).
  - As noted, removal of the suppress wrappers prevents the validators from logging any other issues with a given object. After testing, this was confirmed to be undesirable.

- > An alternate fix may be to explicitly validate the presence of the dataclass version of the provided and accessed objects in response_mask_runner.py to ensure field-access errors (using dot-notation to access fields of dicts, etc.) are avoided, and the root issue (failure to create the dataclass representation) is reported clearly.
  - This approach is unwieldy, as it would require a type-check before the first access of each subfield (including nested subfields, of which there are many).

I also considered adding an explicit recursive type-check in test_main after converting the response JSON to object form, external to the validator. However, this causes the test to be skipped for issues in non-critical fields (like VendorExtensions).

The most comprehensive solution to #18 is likely a combination of the "alternate" fix and the recursive type-checker, implemented by using some hidden class variables identifying "required" fields for iteration over by an explicit type checker. If this PR is not sufficient to alleviate the concerns in #18, I recommend pursuing this option.