### PR TITLE
Decouple SDI spec version from SDI protocol version

### DIFF
--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -36,7 +36,7 @@ Harness configuration files are located in `./cfg`. Detailed descriptions of eac
     *   By default, the `{inquiries_dir}` directory is `./inquiries` and the `{masks_dir}` directory is `./masks`.
 
 ## Specification version
-AFC communication and message validation is performed according to the current version of the Wi-Fi Alliance AFC System to AFC Device Interface Specification (v1.3.2). Tests are executed and evaluated according to the current version fo the Wi-Fi Alliance AFC System Under Test (SUT) Compliance Test Plan (v1.3). These specifications are available from the [Wi-Fi Alliance website](https://www.wi-fi.org/discover-wi-fi/specifications) under "AFC Specification and Test Plans."
+AFC communication and message validation is performed according to the current version of the Wi-Fi Alliance AFC System to AFC Device Interface Specification Protocol (v1.3). Tests are executed and evaluated according to the current version fo the Wi-Fi Alliance AFC System Under Test (SUT) Compliance Test Plan (v1.3). These specifications are available from the [Wi-Fi Alliance website](https://www.wi-fi.org/discover-wi-fi/specifications) under "AFC Specification and Test Plans."
 
 ## Sample files
 Example json files for the inquiry request, response, and response mask are provided as:

--- a/src/harness/available_spectrum_inquiry_response.py
+++ b/src/harness/available_spectrum_inquiry_response.py
@@ -11,12 +11,12 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""Available Spectrum Inquiry Response Definitions - SDI v1.3.2"""
+"""Available Spectrum Inquiry Response Definitions - SDI Protocol v1.3"""
 
 import enum
 import json
 from dataclasses import dataclass
-from typing import Any, Union
+from typing import Union
 from contextlib import suppress
 
 from interface_common import FrequencyRange, VendorExtension, init_from_dicts

--- a/src/harness/expected_inquiry_response.py
+++ b/src/harness/expected_inquiry_response.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""Expected Available Spectrum Inquiry Response Definitions - SDI v1.3.2"""
+"""Expected Available Spectrum Inquiry Response Definitions"""
 
 from dataclasses import dataclass
 from contextlib import suppress

--- a/src/harness/interface_common.py
+++ b/src/harness/interface_common.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC System to AFC Device Interface Common Classes - SDI v1.3.2"""
+"""AFC System to AFC Device Interface Common Classes - SDI Protocol v1.3"""
 
 from dataclasses import dataclass
 from typing import Any
@@ -21,9 +21,9 @@ class FrequencyRange:
   """Frequency Range specification for spectrum availability requests and responses
 
   Ranges run from lowFrequency (inclusive) up to but not including highFrequency,
-  that is: the range [lowFrequency, highFrequency). Current SDI spec (v1.3.2) does not specify
-  this interpretation, but it is implied by the spec's sample_response (contiguous frequency
-  ranges sharing a high/low freq value)
+  that is: the range [lowFrequency, highFrequency). Current SDI spec (as of protocol v1.3) does not
+  specify this interpretation, but it is implied by the spec's sample_response (contiguous
+  frequency ranges sharing a high/low freq value)
 
   Attributes:
     lowFrequency: lowest frequency in the range, expressed in MHz

--- a/src/harness/request_validator.py
+++ b/src/harness/request_validator.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-"""AFC Spectrum Inquiry Request Validation - SDI v1.3.2
+"""AFC Spectrum Inquiry Request Validation - SDI Protocol v1.3
 
 Validates a text file containing a spectrum inquiry request in the WFA
 standard format. Checks:

--- a/src/harness/response_mask_runner.py
+++ b/src/harness/response_mask_runner.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC Spectrum Inquiry Response Mask Runner - SDI v1.3.2, SUT Test Plan v1.3
+"""AFC Spectrum Inquiry Response Mask Runner - SDI Protocol v1.3, SUT Test Plan v1.3
 
 Mask runner functions will compare the provided response mask to a received response
 and provide an expected/unexpected result, logging results along the way. Comparison is performed

--- a/src/harness/response_mask_validator.py
+++ b/src/harness/response_mask_validator.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC Spectrum Inquiry Expected Response Validation - SDI v1.3.2
+"""AFC Spectrum Inquiry Expected Response Validation - SDI Protocol v1.3
 
 Validation functions will exhaustively test all fields (i.e.,
 validation does not stop on the first failure, but will report all

--- a/src/harness/response_validator.py
+++ b/src/harness/response_validator.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC Spectrum Inquiry Response Validation - SDI v1.3.2
+"""AFC Spectrum Inquiry Response Validation - SDI Protocol v1.3
 
 Validation functions will exhaustively test all fields (i.e.,
 validation does not stop on the first failure, but will report all

--- a/src/harness/sdi_validator_common.py
+++ b/src/harness/sdi_validator_common.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC Common SDI Validation - SDI v1.3.2
+"""AFC Common SDI Validation - SDI Protocol v1.3
 
 Validation functions will exhaustively test all fields (i.e.,
 validation does not stop on the first failure, but will report all


### PR DESCRIPTION
Goal is to reduce need to version bump file headers/documentation for small, editorial updates to SDI document. Large changes that impact harness implementation are expected to cause the protocol version number to be updated.

Also removes unneeded Any import left over from
d5a8b849ea2392bc4d1b2582ea78f20375fa7ab7