### PR TITLE
Updates for Feb 2023 WFA Document Versions

### DIFF
--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -35,8 +35,12 @@ Harness configuration files are located in `./cfg`. Detailed descriptions of eac
 *   **./cfg/tests_to_run.py**: Specify tests to run from the `{inquiries_dir}` directory. If 'all' is listed first, harness executes on all `(test_name).json` files in `{inquiries_dir}`. Corresponding response masks should be placed in the `{masks_dir}` directory, named as `(test_name)_mask.json`. This file should contain a valid python function that returns a list of test names.
     *   By default, the `{inquiries_dir}` directory is `./inquiries` and the `{masks_dir}` directory is `./masks`.
 
-## Specification version
-AFC communication and message validation is performed according to the current version of the Wi-Fi Alliance AFC System to AFC Device Interface Specification Protocol (v1.3). Tests are executed and evaluated according to the current version fo the Wi-Fi Alliance AFC System Under Test (SUT) Compliance Test Plan (v1.3). These specifications are available from the [Wi-Fi Alliance website](https://www.wi-fi.org/discover-wi-fi/specifications) under "AFC Specification and Test Plans."
+## Specification versions
+AFC communication and message validation is performed according to the current version of the Wi-Fi Alliance AFC System to AFC Device Interface Specification Protocol (protocol v1.3, as defined in specification v1.4).
+
+Tests are executed and evaluated according to the current version of the Wi-Fi Alliance AFC System Under Test (SUT) Compliance Test Plan (v1.4).
+
+These specifications and test vectors are available from the [Wi-Fi Alliance website](https://www.wi-fi.org/discover-wi-fi/specifications) under "AFC Specification and Test Plans."
 
 ## Sample files
 Example json files for the inquiry request, response, and response mask are provided as:

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -40,6 +40,8 @@ AFC communication and message validation is performed according to the current v
 
 Tests are executed and evaluated according to the current version of the Wi-Fi Alliance AFC System Under Test (SUT) Compliance Test Plan (v1.4).
 
+JSON-formatted test vector inquries provided in `./inquiries` are from the Wi-Fi Alliance AFC System (SUT) Compliance Test Vector Requests (v1.1). 
+
 These specifications and test vectors are available from the [Wi-Fi Alliance website](https://www.wi-fi.org/discover-wi-fi/specifications) under "AFC Specification and Test Plans."
 
 ## Sample files

--- a/src/harness/inquiries/AFCS.FSP.1.json
+++ b/src/harness/inquiries/AFCS.FSP.1.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP1",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP1",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP1"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.10.json
+++ b/src/harness/inquiries/AFCS.FSP.10.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP10",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP10",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP10"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.100.json
+++ b/src/harness/inquiries/AFCS.FSP.100.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP1",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP1",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP1"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [
@@ -63,11 +63,11 @@
     {
       "requestId": "REQ-FSP2",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP2",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP2"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [
@@ -122,11 +122,11 @@
     {
       "requestId": "REQ-FSP3",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP3",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP3"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [
@@ -181,11 +181,11 @@
     {
       "requestId": "REQ-FSP4",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP4",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP4"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [
@@ -240,11 +240,11 @@
     {
       "requestId": "REQ-FSP5",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP5",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP5"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [
@@ -299,11 +299,11 @@
     {
       "requestId": "REQ-FSP6",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP6",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP6"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [
@@ -358,11 +358,11 @@
     {
       "requestId": "REQ-FSP7",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP7",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP7"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.11.json
+++ b/src/harness/inquiries/AFCS.FSP.11.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP11",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP11",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP11"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.12.json
+++ b/src/harness/inquiries/AFCS.FSP.12.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP12",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP12",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP12"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.13.json
+++ b/src/harness/inquiries/AFCS.FSP.13.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP13",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP13",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP13"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.14.json
+++ b/src/harness/inquiries/AFCS.FSP.14.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP14",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP14",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP14"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.15.json
+++ b/src/harness/inquiries/AFCS.FSP.15.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP15",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP15",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP15"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.16.json
+++ b/src/harness/inquiries/AFCS.FSP.16.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP16",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP16",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP16"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.17.json
+++ b/src/harness/inquiries/AFCS.FSP.17.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP17",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP17",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP17"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.18.json
+++ b/src/harness/inquiries/AFCS.FSP.18.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP18",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP18",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP18"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.19.json
+++ b/src/harness/inquiries/AFCS.FSP.19.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP19",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP19",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP19"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.2.json
+++ b/src/harness/inquiries/AFCS.FSP.2.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP2",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP2",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP2"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.20.json
+++ b/src/harness/inquiries/AFCS.FSP.20.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP20",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP20",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP20"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.21.json
+++ b/src/harness/inquiries/AFCS.FSP.21.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP21",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP21",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP21"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.22.json
+++ b/src/harness/inquiries/AFCS.FSP.22.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP22",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP22",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP22"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.23.json
+++ b/src/harness/inquiries/AFCS.FSP.23.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP23",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP23",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP23"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.24.json
+++ b/src/harness/inquiries/AFCS.FSP.24.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP24",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP24",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP24"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.25.json
+++ b/src/harness/inquiries/AFCS.FSP.25.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP25",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP25",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP25"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.26.json
+++ b/src/harness/inquiries/AFCS.FSP.26.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP26",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP26",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP26"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.27.json
+++ b/src/harness/inquiries/AFCS.FSP.27.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP27",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP27",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP27"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.28.json
+++ b/src/harness/inquiries/AFCS.FSP.28.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP28",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP28",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP28"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.29.json
+++ b/src/harness/inquiries/AFCS.FSP.29.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP29",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP29",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP29"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.3.json
+++ b/src/harness/inquiries/AFCS.FSP.3.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP3",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP3",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP3"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.30.json
+++ b/src/harness/inquiries/AFCS.FSP.30.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP30",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP30",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP30"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.31.json
+++ b/src/harness/inquiries/AFCS.FSP.31.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP31",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP31",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP31"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.32.json
+++ b/src/harness/inquiries/AFCS.FSP.32.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP32",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP32",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP32"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.33.json
+++ b/src/harness/inquiries/AFCS.FSP.33.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP33",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP33",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP33"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.34.json
+++ b/src/harness/inquiries/AFCS.FSP.34.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP34",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP34",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP34"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.35.json
+++ b/src/harness/inquiries/AFCS.FSP.35.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP35",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP35",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP35"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.36.json
+++ b/src/harness/inquiries/AFCS.FSP.36.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP36",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP36",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP36"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.37.json
+++ b/src/harness/inquiries/AFCS.FSP.37.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP37",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP37",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP37"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.38.json
+++ b/src/harness/inquiries/AFCS.FSP.38.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP38",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP38",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP38"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.39.json
+++ b/src/harness/inquiries/AFCS.FSP.39.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP39",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP39",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP39"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.4.json
+++ b/src/harness/inquiries/AFCS.FSP.4.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP4",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP4",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP4"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.40.json
+++ b/src/harness/inquiries/AFCS.FSP.40.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP40",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP40",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP40"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.41.json
+++ b/src/harness/inquiries/AFCS.FSP.41.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP41",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP41",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP41"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.42.json
+++ b/src/harness/inquiries/AFCS.FSP.42.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP42",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP42",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP42"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.43.json
+++ b/src/harness/inquiries/AFCS.FSP.43.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP43",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP43",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP43"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.44.json
+++ b/src/harness/inquiries/AFCS.FSP.44.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP44",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP44",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP44"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.45.json
+++ b/src/harness/inquiries/AFCS.FSP.45.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP45",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP45",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP45"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.46.json
+++ b/src/harness/inquiries/AFCS.FSP.46.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP46",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP46",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP46"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.47.json
+++ b/src/harness/inquiries/AFCS.FSP.47.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP47",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP47",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP47"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.48.json
+++ b/src/harness/inquiries/AFCS.FSP.48.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP48",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP48",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP48"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.49.json
+++ b/src/harness/inquiries/AFCS.FSP.49.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP49",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP49",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP49"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.5.json
+++ b/src/harness/inquiries/AFCS.FSP.5.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP5",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP5",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP5"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.50.json
+++ b/src/harness/inquiries/AFCS.FSP.50.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP50",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP50",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP50"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.51.json
+++ b/src/harness/inquiries/AFCS.FSP.51.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP51",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP51",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP51"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.52.json
+++ b/src/harness/inquiries/AFCS.FSP.52.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP52",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP52",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP52"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.53.json
+++ b/src/harness/inquiries/AFCS.FSP.53.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP53",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP53",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP53"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.54.json
+++ b/src/harness/inquiries/AFCS.FSP.54.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP54",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP54",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP54"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.55.json
+++ b/src/harness/inquiries/AFCS.FSP.55.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP55",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP55",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP55"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.56.json
+++ b/src/harness/inquiries/AFCS.FSP.56.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP56",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP56",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP56"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.57.json
+++ b/src/harness/inquiries/AFCS.FSP.57.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP57",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP57",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP57"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.58.json
+++ b/src/harness/inquiries/AFCS.FSP.58.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP58",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP58",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP58"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.59.json
+++ b/src/harness/inquiries/AFCS.FSP.59.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP59",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP59",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP59"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.6.json
+++ b/src/harness/inquiries/AFCS.FSP.6.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP6",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP6",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP6"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.60.json
+++ b/src/harness/inquiries/AFCS.FSP.60.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP60",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP60",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP60"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.61.json
+++ b/src/harness/inquiries/AFCS.FSP.61.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP61",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP61",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP61"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.62.json
+++ b/src/harness/inquiries/AFCS.FSP.62.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP62",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP62",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP62"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.63.json
+++ b/src/harness/inquiries/AFCS.FSP.63.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP63",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP63",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP63"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.65.json
+++ b/src/harness/inquiries/AFCS.FSP.65.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP65",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP65",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP65"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.66.json
+++ b/src/harness/inquiries/AFCS.FSP.66.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP66",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP66",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP66"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.67.json
+++ b/src/harness/inquiries/AFCS.FSP.67.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP67",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP67",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP67"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.68.json
+++ b/src/harness/inquiries/AFCS.FSP.68.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP68",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP68",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP68"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.69.json
+++ b/src/harness/inquiries/AFCS.FSP.69.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP69",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP69",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP69"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.7.json
+++ b/src/harness/inquiries/AFCS.FSP.7.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP7",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP7",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP7"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.70.json
+++ b/src/harness/inquiries/AFCS.FSP.70.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP70",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP70",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP70"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.71.json
+++ b/src/harness/inquiries/AFCS.FSP.71.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP71",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP71",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP71"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.72.json
+++ b/src/harness/inquiries/AFCS.FSP.72.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP72",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP72",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP72"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.73.json
+++ b/src/harness/inquiries/AFCS.FSP.73.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP73",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP73",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP73"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.74.json
+++ b/src/harness/inquiries/AFCS.FSP.74.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP74",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP74",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP74"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.75.json
+++ b/src/harness/inquiries/AFCS.FSP.75.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP75",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP75",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP75"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.76.json
+++ b/src/harness/inquiries/AFCS.FSP.76.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP76",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP76",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP76"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.77.json
+++ b/src/harness/inquiries/AFCS.FSP.77.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP77",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP77",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP77"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.78.json
+++ b/src/harness/inquiries/AFCS.FSP.78.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP78",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP78",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP78"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.79.json
+++ b/src/harness/inquiries/AFCS.FSP.79.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP79",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP79",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP79"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.8.json
+++ b/src/harness/inquiries/AFCS.FSP.8.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP8",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP8",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP8"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.80.json
+++ b/src/harness/inquiries/AFCS.FSP.80.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP80",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP80",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP80"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.81.json
+++ b/src/harness/inquiries/AFCS.FSP.81.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP81",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP81",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP81"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.82.json
+++ b/src/harness/inquiries/AFCS.FSP.82.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP82",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP82",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP82"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.83.json
+++ b/src/harness/inquiries/AFCS.FSP.83.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP83",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP83",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP83"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.84.json
+++ b/src/harness/inquiries/AFCS.FSP.84.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP84",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP84",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP84"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.85.json
+++ b/src/harness/inquiries/AFCS.FSP.85.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP85",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP85",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP85"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.86.json
+++ b/src/harness/inquiries/AFCS.FSP.86.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP86",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP86",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP86"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.87.json
+++ b/src/harness/inquiries/AFCS.FSP.87.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP87",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP87",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP87"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.88.json
+++ b/src/harness/inquiries/AFCS.FSP.88.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP88",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP88",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP88"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.89.json
+++ b/src/harness/inquiries/AFCS.FSP.89.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP89",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP89",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP89"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.9.json
+++ b/src/harness/inquiries/AFCS.FSP.9.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP9",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP9",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP9"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.90.json
+++ b/src/harness/inquiries/AFCS.FSP.90.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP90",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP90",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP90"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.91.json
+++ b/src/harness/inquiries/AFCS.FSP.91.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP91",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP91",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP91"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.92.json
+++ b/src/harness/inquiries/AFCS.FSP.92.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP92",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP92",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP92"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.93.json
+++ b/src/harness/inquiries/AFCS.FSP.93.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP93",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP93",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP93"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.94.json
+++ b/src/harness/inquiries/AFCS.FSP.94.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP94",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP94",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP94"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.95.json
+++ b/src/harness/inquiries/AFCS.FSP.95.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP95",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP95",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP95"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.96.json
+++ b/src/harness/inquiries/AFCS.FSP.96.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP96",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP96",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP96"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.97.json
+++ b/src/harness/inquiries/AFCS.FSP.97.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP97",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP97",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP97"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.98.json
+++ b/src/harness/inquiries/AFCS.FSP.98.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP98",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP98",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP98"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.FSP.99.json
+++ b/src/harness/inquiries/AFCS.FSP.99.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-FSP99",
       "deviceDescriptor": {
-        "serialNumber": "SN-FSP99",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-FSP99"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.IBP.1.json
+++ b/src/harness/inquiries/AFCS.IBP.1.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-IBP1",
       "deviceDescriptor": {
-        "serialNumber": "SN-IBP1",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-IBP1"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [
@@ -24,7 +24,7 @@
         "ellipse": {
           "center": {
             "longitude": -84.331771,
-            "latitude": 46.596068
+            "latitude": 46.4968
           },
           "majorAxis": 30,
           "minorAxis": 30,

--- a/src/harness/inquiries/AFCS.IBP.2.json
+++ b/src/harness/inquiries/AFCS.IBP.2.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-IBP2",
       "deviceDescriptor": {
-        "serialNumber": "SN-IBP2",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-IBP2"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.IBP.3.json
+++ b/src/harness/inquiries/AFCS.IBP.3.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-IBP3",
       "deviceDescriptor": {
-        "serialNumber": "SN-IBP3",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-IBP3"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.IBP.4.json
+++ b/src/harness/inquiries/AFCS.IBP.4.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-IBP4",
       "deviceDescriptor": {
-        "serialNumber": "SN-IBP4",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-IBP4"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.IBP.5.json
+++ b/src/harness/inquiries/AFCS.IBP.5.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-IBP5",
       "deviceDescriptor": {
-        "serialNumber": "SN-IBP5",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-IBP5"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.IBP.6.json
+++ b/src/harness/inquiries/AFCS.IBP.6.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-IBP6",
       "deviceDescriptor": {
-        "serialNumber": "SN-IBP6",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-IBP6"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.IBP.7.json
+++ b/src/harness/inquiries/AFCS.IBP.7.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-IBP7",
       "deviceDescriptor": {
-        "serialNumber": "SN-IBP7",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-IBP7"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.IBP.8.json
+++ b/src/harness/inquiries/AFCS.IBP.8.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-IBP8",
       "deviceDescriptor": {
-        "serialNumber": "SN-IBP8",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-IBP8"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.1.json
+++ b/src/harness/inquiries/AFCS.SIP.1.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP1",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP1",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP1"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.10.json
+++ b/src/harness/inquiries/AFCS.SIP.10.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP10",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP10",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP10"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.11.json
+++ b/src/harness/inquiries/AFCS.SIP.11.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP11",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP11",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP11"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.12.json
+++ b/src/harness/inquiries/AFCS.SIP.12.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP12",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP12",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP12"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.13.json
+++ b/src/harness/inquiries/AFCS.SIP.13.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP13",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP13",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP13"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.14.json
+++ b/src/harness/inquiries/AFCS.SIP.14.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP14",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP14",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP14"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.15.json
+++ b/src/harness/inquiries/AFCS.SIP.15.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP15",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP15",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP15"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.16.json
+++ b/src/harness/inquiries/AFCS.SIP.16.json
@@ -2,7 +2,7 @@
   "version": "1.3",
   "availableSpectrumInquiryRequests": [
     {
-      "requestId": "REQ-FSP64",
+      "requestId": "REQ-SIP16",
       "deviceDescriptor": {
         "serialNumber": "REG123",
         "certificationId": [
@@ -17,20 +17,20 @@
       },
       "location": {
         "elevation": {
-          "height": 3.0,
+          "height": 14.2,
           "heightType": "AGL",
-          "verticalUncertainty": 2
+          "verticalUncertainty": 1
         },
         "ellipse": {
           "center": {
-            "longitude": -120.695567,
-            "latitude": 38.816705
+            "longitude": -119.62,
+            "latitude": 48.996
           },
-          "majorAxis": 100,
-          "minorAxis": 50,
-          "orientation": 45.0
+          "majorAxis": 10,
+          "minorAxis": 10,
+          "orientation": 0.0
         },
-        "indoorDeployment": 1
+        "indoorDeployment": 0
       },
       "inquiredFrequencyRange": [
         {

--- a/src/harness/inquiries/AFCS.SIP.2.json
+++ b/src/harness/inquiries/AFCS.SIP.2.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP2",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP2",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP2"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.3.json
+++ b/src/harness/inquiries/AFCS.SIP.3.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP3",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP3",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP3"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.4.json
+++ b/src/harness/inquiries/AFCS.SIP.4.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP4",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP4",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP4"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.5.json
+++ b/src/harness/inquiries/AFCS.SIP.5.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP5",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP5",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP5"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.6.json
+++ b/src/harness/inquiries/AFCS.SIP.6.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP6",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP6",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP6"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.7.json
+++ b/src/harness/inquiries/AFCS.SIP.7.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP7",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP7",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP7"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.8.json
+++ b/src/harness/inquiries/AFCS.SIP.8.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP8",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP8",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP8"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SIP.9.json
+++ b/src/harness/inquiries/AFCS.SIP.9.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SIP9",
       "deviceDescriptor": {
-        "serialNumber": "SN-SIP9",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SIP9"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.SRS.1.json
+++ b/src/harness/inquiries/AFCS.SRS.1.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-SRS1",
       "deviceDescriptor": {
-        "serialNumber": "SN-SRS1",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-SRS1"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.URS.1.json
+++ b/src/harness/inquiries/AFCS.URS.1.json
@@ -4,7 +4,7 @@
     {
       "requestId": "REQ-URS1",
       "deviceDescriptor": {
-        "serialNumber": "SN-URS1",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC"

--- a/src/harness/inquiries/AFCS.URS.2.json
+++ b/src/harness/inquiries/AFCS.URS.2.json
@@ -7,7 +7,7 @@
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-URS2"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.URS.3.json
+++ b/src/harness/inquiries/AFCS.URS.3.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-URS3",
       "deviceDescriptor": {
-        "serialNumber": "SN-URS3",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-URS3"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.URS.4.json
+++ b/src/harness/inquiries/AFCS.URS.4.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-URS4",
       "deviceDescriptor": {
-        "serialNumber": "SN-URS4",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-URS4"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.URS.5.json
+++ b/src/harness/inquiries/AFCS.URS.5.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-URS5",
       "deviceDescriptor": {
-        "serialNumber": "SN-URS5",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-URS5"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.URS.6.json
+++ b/src/harness/inquiries/AFCS.URS.6.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-URS6",
       "deviceDescriptor": {
-        "serialNumber": "SN-URS6",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-URS6"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/inquiries/AFCS.URS.7.json
+++ b/src/harness/inquiries/AFCS.URS.7.json
@@ -4,11 +4,11 @@
     {
       "requestId": "REQ-URS7",
       "deviceDescriptor": {
-        "serialNumber": "SN-URS7",
+        "serialNumber": "REG123",
         "certificationId": [
           {
             "nra": "FCC",
-            "id": "FCCID-URS7"
+            "id": "FCCID-REG123"
           }
         ],
         "rulesetIds": [

--- a/src/harness/interface_common.py
+++ b/src/harness/interface_common.py
@@ -21,8 +21,8 @@ class FrequencyRange:
   """Frequency Range specification for spectrum availability requests and responses
 
   Ranges run from lowFrequency (inclusive) up to but not including highFrequency,
-  that is: the range [lowFrequency, highFrequency). Current SDI spec (as of protocol v1.3) does not
-  specify this interpretation, but it is implied by the spec's sample_response (contiguous
+  that is: the range [lowFrequency, highFrequency). Current SDI spec (as of protocol document v1.4)
+  does not specify this interpretation, but it is implied by the spec's sample_response (contiguous
   frequency ranges sharing a high/low freq value)
 
   Attributes:

--- a/src/harness/response_mask_runner.py
+++ b/src/harness/response_mask_runner.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""AFC Spectrum Inquiry Response Mask Runner - SDI Protocol v1.3, SUT Test Plan v1.3
+"""AFC Spectrum Inquiry Response Mask Runner - SDI Protocol v1.3, SUT Test Plan v1.4
 
 Mask runner functions will compare the provided response mask to a received response
 and provide an expected/unexpected result, logging results along the way. Comparison is performed


### PR DESCRIPTION
- Updates test vector inquiry JSON files to WFA v1.1
  - Changes inquiry serial number and FCC ID to be same for all tests, rather than unique to each test
  - Corrects a location in AFCS.IBP.1
  - Adds a new vector for AFCS.SIP.16
  - Adds reference to test vector inquiry source to README
- Bump SUT Test Plan version number (v1.4)
- Clarify decoupled SDI protocol version in README