### PR TITLE
Relax restriction on allowed mask response codes

### DIFF
--- a/src/harness/expected_inquiry_response.py
+++ b/src/harness/expected_inquiry_response.py
@@ -130,7 +130,7 @@ class ExpectedSpectrumInquiryResponse:
   """
   requestId: str
   rulesetId: str
-  expectedResponseCodes: list[afc_resp.ResponseCode]
+  expectedResponseCodes: list[Union[afc_resp.ResponseCode, int]]
   expectedFrequencyInfo: list[ExpectedAvailableFrequencyInfo] = None
   expectedChannelInfo: list[ExpectedAvailableChannelInfo] = None
   vendorExtensions: list[afc_resp.VendorExtension] = None

--- a/src/harness/response_mask_runner.py
+++ b/src/harness/response_mask_runner.py
@@ -41,6 +41,7 @@ class ResponseMaskRunner(TestHarnessLogger):
       rulesetId matches
       response.responseCode is not disallowed (permits expected codes or vendor extension codes)
         Logs warning on vendor extension codes--may merit manual review
+      Availability info is not provided unless response.responseCode is SUCCESS
       No response frequency ranges overlap disallowed ranges
       All response frequency range PSDs are within permitted ranges
       No response channels are granted that are not in mask
@@ -109,6 +110,11 @@ class ResponseMaskRunner(TestHarnessLogger):
 
     # Frequency range checks
     if received.availableFrequencyInfo is not None:
+      # Ensure that response code is success
+      if (afc_resp.ResponseCode.get_raw_value(received.response.responseCode) !=
+          afc_resp.ResponseCode.SUCCESS.value):
+        received_expected = False
+        self._error('Response contains frequency info but did not indicate SUCCESS')
       # Does not provide availability info of basis not specified in mask
       if expected.expectedFrequencyInfo is None:
         received_expected = False
@@ -146,6 +152,11 @@ class ResponseMaskRunner(TestHarnessLogger):
               curr_freq = high_disallow_freq
 
     if received.availableChannelInfo is not None:
+      # Ensure that response code is success
+      if (afc_resp.ResponseCode.get_raw_value(received.response.responseCode) !=
+          afc_resp.ResponseCode.SUCCESS.value):
+        received_expected = False
+        self._error('Response contains channel info but did not indicate SUCCESS')
       # Does not provide availability info of basis not specified in mask
       if expected.expectedChannelInfo is None:
         received_expected = False

--- a/src/harness/response_mask_validator.py
+++ b/src/harness/response_mask_validator.py
@@ -164,7 +164,6 @@ class ResponseMaskValidator(sdi_validate.SDIValidatorBase):
       At least one expectedResponseCode is given
       expectedResponseCodes are valid
       If SUCCESS is expected response code:
-        No other codes are expected
         At least one of expectedChannelInfo and expectedFrequencyInfo is given
       If SUCCESS is not expected response code:
         No availability info is given
@@ -198,10 +197,6 @@ class ResponseMaskValidator(sdi_validate.SDIValidatorBase):
         # If SUCCESS is expected response code:
         if any(afc_exp.afc_resp.ResponseCode.get_raw_value(code) ==
               afc_exp.afc_resp.ResponseCode.SUCCESS.value for code in exp.expectedResponseCodes):
-          # No other codes are expected
-          if len(exp.expectedResponseCodes) > 1:
-            is_valid = False
-            self._warning('Cannot expect SUCCESS and other response codes in the same message')
 
           # At least one of expectedChannelInfo and expectedFrequencyInfo is given
           if exp.expectedChannelInfo is None and exp.expectedFrequencyInfo is None:


### PR DESCRIPTION
This PR resolves #30.

Changes include:
Allowing a response mask to expect SUCCESS at the same time as non-SUCCESS response codes
Ensuring that a response only contains availability info if the response code is SUCCESS
Fixes the expected type for expected response codes (now allows non-standard codes)