### PR TITLE
Fix maximum value for channel EIRPs in mask_sample.json

### DIFF
--- a/src/harness/mask_sample.json
+++ b/src/harness/mask_sample.json
@@ -75,22 +75,22 @@
                         },
                         {
                             "nominalValue": 36,
-                            "upperBound": 36.5,
+                            "upperBound": 36,
                             "lowerBound": 35.5
                         },
                         {
                             "nominalValue": 36,
-                            "upperBound": 36.5,
+                            "upperBound": 36,
                             "lowerBound": 35.5
                         },
                         {
                             "nominalValue": 36,
-                            "upperBound": 36.5,
+                            "upperBound": 36,
                             "lowerBound": 35.5
                         },
                         {
                             "nominalValue": 36,
-                            "upperBound": 36.5,
+                            "upperBound": 36,
                             "lowerBound": 35.5
                         },
                         {
@@ -100,7 +100,7 @@
                         },
                         {
                             "nominalValue": 36,
-                            "upperBound": 36.5,
+                            "upperBound": 36,
                             "lowerBound": 35.5
                         }
                     ]
@@ -113,7 +113,7 @@
                     "maxEirp": [
                         {
                             "nominalValue": 35,
-                            "upperBound": 36.5,
+                            "upperBound": 36,
                             "lowerBound": 33
                         }
                     ]


### PR DESCRIPTION
Had previosuly neglected to consider max values permitted per FCC rules when creating example mask Revised mask_sample.json should be within FCC permitted values