### PR TITLE
Relax HTTP status code check

### DIFF
--- a/src/harness/expected_inquiry_response.py
+++ b/src/harness/expected_inquiry_response.py
@@ -164,12 +164,12 @@ class ExpectedSpectrumInquiryResponse:
             with suppress(ValueError):
               self.disallowedResponseCodes[idx] = ResponseCode(code)
     if self.expectedFrequencyInfo is not None:
-      with suppress(TypeError):
+      with suppress(TypeError, AttributeError):
         self.expectedFrequencyInfo = init_from_dicts(self.expectedFrequencyInfo,
                                                       ExpectedAvailableFrequencyInfo)
         self.expectedFrequencyInfo.sort(key=attrgetter('frequencyRange.lowFrequency'))
     if self.expectedChannelInfo is not None:
-      with suppress(TypeError):
+      with suppress(TypeError, AttributeError):
         self.expectedChannelInfo = init_from_dicts(self.expectedChannelInfo,
                                                    ExpectedAvailableChannelInfo)
         self.expectedChannelInfo.sort(key=attrgetter('channelCfi'))

--- a/src/harness/interface_common.py
+++ b/src/harness/interface_common.py
@@ -129,7 +129,13 @@ def init_from_dicts(dicts: list[dict], cls):
   Returns:
     dicts with all dictionaries converted to objects of type cls
   """
-  return [cls(**x) if isinstance(x, dict) else x for x in dicts]
+  def safe_init(x, cls):
+    try:
+      return cls(**x)
+    except Exception:
+      return x
+
+  return [safe_init(x, cls) if isinstance(x, dict) else x for x in dicts]
 
 class JSONEncoderSDI(json.JSONEncoder):
   """Modified version of JSONEncoder that serializes dataclasses and SDI-specific behavior."""

--- a/src/harness/interface_common.py
+++ b/src/harness/interface_common.py
@@ -164,18 +164,11 @@ class JSONEncoderSDI(json.JSONEncoder):
     if isinstance(value, list):
       return [cls.clean_nones(x) for x in value if x is not None]
     elif isinstance(value, dict):
-      try:
-        return {
-          key: cls.clean_nones(val)
-          for key, val in value.items()
-          if val is not None and val != float('-inf')
-        }
-      except:
-        return {
-          key: cls.clean_nones(val)
-          for key, val in value.items()
-          if val is not None and val != float('-inf')
-        }
+      return {
+        key: cls.clean_nones(val)
+        for key, val in value.items()
+        if val is not None and val != float('-inf')
+      }
     else:
       return value
 

--- a/src/harness/masks/README.md
+++ b/src/harness/masks/README.md
@@ -5,4 +5,4 @@ These response masks are from the Wi-Fi Alliance AFC System (SUT) Compliance Tes
 Implementation notes:
   * The mask file for AFCS.SRS.1 has been created to allow the maximum allowed power for the requested frequency ranges and all channel indices in the requested global operating classes (according to the channel index list in Table E-4 of [IEEE 802.11ax-2021](https://ieeexplore.ieee.org/document/9442429)).
   * The URS test cases also permit -1 (GENERAL_FAILURE), in addition to the more specific (but optional) codes listed in the test vectors document.
-  * AFCS.URS.1 has been fixed to expect a response code of 102 (MISSING_PARAM) in addition to 103 (INVALID_VALUE) to better align with the current request definition (which, rather tha including an invalid device ID, instead does not include a value for the device ID).
+  * AFCS.URS.1 has been fixed to expect a response code of 102 (MISSING_PARAM) in addition to 103 (INVALID_VALUE) to better align with the current request definition (which, rather than including an invalid device ID, instead does not include a value for the device ID).

--- a/src/harness/request_validator.py
+++ b/src/harness/request_validator.py
@@ -808,7 +808,7 @@ class InquiryRequestValidator(sdi_validate.SDIValidatorBase):
           self._warning('Message should have no more than one occurrence of any given requestId')
     except (TypeError, AttributeError) as ex:
       is_valid = False
-      self._warning(f'Exception caught validating responses: {ex}')
+      self._warning(f'Exception caught validating requests: {ex}')
 
     # vendorExtensions are valid
     is_valid &= self.validate_vendor_extension_list(msg.vendorExtensions)

--- a/src/harness/request_validator.py
+++ b/src/harness/request_validator.py
@@ -763,6 +763,18 @@ class InquiryRequestValidator(sdi_validate.SDIValidatorBase):
       Each AvailableSpectrumInquiryRequest has a unique requestId
       vendorExtensions are valid
 
+    Warns:
+      If request message contains a mixture of valid and invalid requests
+        This situation may be handled differently by various AFC implementations,
+        making the creation of a mask file difficult. For instance, an AFC might:
+          * Process each request individually, returning HTTP code 200 and a mix of
+            SDI SUCCESS and error response codes
+          * Ignore any valid requests within the message, returning HTTP code 400 and
+            the relevant SDI error response codes for each request
+        Use of mixed valid and invalid requests is discouraged within a single request message.
+        See GitHub PR #41 (https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/pull/41)
+        for more details.
+
     Parameters:
       msg (AvailableSpectrumInquiryRequestMessage): Message to be validated
 
@@ -778,8 +790,15 @@ class InquiryRequestValidator(sdi_validate.SDIValidatorBase):
                       f'list must be at least 1: {msg.availableSpectrumInquiryRequests}')
       else:
         # availableSpectrumInquiryRequests exist and are all valid
-        is_valid &= all([self.validate_available_spectrum_inquiry_request(x)
-                        for x in msg.availableSpectrumInquiryRequests])
+        valid_request_flags = [self.validate_available_spectrum_inquiry_request(x)
+                               for x in msg.availableSpectrumInquiryRequests]
+        is_valid &= all(valid_request_flags)
+
+        # Log a special warning for mixtures of valid and invalid requests
+        if True in valid_request_flags and False in valid_request_flags:
+          self._warning('Request message contains a mixture of valid and invalid requests. The '
+                        'expected response for this type of request may be ambiguous '
+                        '(see GitHub PR#41). Issues executing this test may occur in some cases.')
 
         # Each availableSpectrumInquiryRequest has a unique requestID
         resp_ids = [sub_resp.requestId for sub_resp in msg.availableSpectrumInquiryRequests]

--- a/src/harness/test_main.py
+++ b/src/harness/test_main.py
@@ -339,7 +339,7 @@ def main():
       try:
         response = afc_obj.get_last_response()
       except JSONDecodeError as ex:
-        logger.error('Received response could not be decoded as valid JSON. Raw response test: '
+        logger.error('Received response could not be decoded as valid JSON. Raw response text: '
                     f'"{afc_obj.get_last_response(as_json=False)}". Result UNEXPECTED.\n')
         results.add_result(test_name, TestResult.UNEXPECTED)
         continue
@@ -354,15 +354,15 @@ def main():
 
       # Checking that response is valid
       if response_validator.validate_available_spectrum_inquiry_response_message(response):
-        logger.info('Response appears valid.')
+        logger.info('Response content appears valid.')
       else:
-        logger.warning('Response does NOT appear valid. Will attempt test anyway...')
+        logger.warning('Response content does NOT appear valid. Will attempt test anyway...')
 
       logger.debug('Parsing received response as a response object...')
       try:
         response_obj = AvailableSpectrumInquiryResponseMessage(**response)
       except TypeError as ex:
-        logger.error(f'Exception converting response for comparison: {ex}. Test SKIPPED.\n')
+        logger.fatal(f'Exception converting response for comparison: {ex}. Test SKIPPED.\n')
         results.add_result(test_name, TestResult.SKIPPED)
         continue
 

--- a/src/harness/test_main.py
+++ b/src/harness/test_main.py
@@ -274,6 +274,14 @@ def main():
         results.add_result(test_name, TestResult.SKIPPED)
         continue
 
+      # Check if mask is expecting the response to indicate an error (alters handling of HTTP
+      # status code and request validation)
+      expected_error_flags = [any(ResponseCode.get_raw_value(code) != ResponseCode.SUCCESS.value
+                                   for code in exp.expectedResponseCodes)
+                              for exp in mask_obj.expectedSpectrumInquiryResponses]
+      expect_any_error = any(expected_error_flags)
+      expect_only_error = all(expected_error_flags)
+
       # Read the contents of the request file in text format
       logger.debug(f'Loading request file {request_file}...')
       with open(request_file, encoding='utf-8') as fin:
@@ -294,13 +302,11 @@ def main():
       # Validate request JSON
       logger.debug('Validating imported request JSON...')
       if not request_validator.validate_available_spectrum_inquiry_request_message(request_json):
-        logger.info('Request does not pass SDI validation--checking if mask expects an error...')
-        if any(any(ResponseCode.get_raw_value(code) != ResponseCode.SUCCESS.value
-                   for code in exp.expectedResponseCodes)
-               for exp in mask_obj.expectedSpectrumInquiryResponses):
-          logger.info('Mask expects an error code, so sending invalid request anyway.')
+        if expect_any_error:
+          logger.info('Request does not pass SDI validation, but mask expects an error, so '
+                      'sending invalid request anyway.')
         else:
-          logger.fatal('Request does not pass SDI validation, but response mask doesn\'t expect '
+          logger.fatal('Request does not pass SDI validation, and response mask doesn\'t expect '
                        'an error. Test SKIPPED.\n')
           results.add_result(test_name, TestResult.SKIPPED)
           continue
@@ -311,17 +317,23 @@ def main():
       logger.info(f'Sending request to AFC via {afc_obj.get_afc_url()}...')
       afc_obj.send_request(request_json)
 
-      # Check for valid HTTP response and code
+      # Check for valid HTTP response and status code
       resp_code = afc_obj.get_last_http_code()
       if resp_code is None:
         logger.error('Failed to receive an HTTP response from the AFC. Result UNEXPECTED.\n')
         results.add_result(test_name, TestResult.UNEXPECTED)
         continue
-      if not 200 <= resp_code <= 299:
-        logger.error(f'Expected response HTTP code of 2XX, got: {afc_obj.get_last_http_code()}. '
-                      'Result UNEXPECTED.\n')
-        results.add_result(test_name, TestResult.UNEXPECTED)
-        continue
+      # If HTTP status code is not expected, test result will be UNEXPECTED, but run the rest of
+      # the test anyway for logging/reporting purposes
+      http_code_mismatch = False
+      # Allow HTTP status code 400 if no successful response is expected
+      if not (200 <= resp_code <= 299 or (expect_only_error and resp_code == 400)):
+        http_code_mismatch = True
+        logger.error(f'Expected HTTP status code of 2XX{" or 400" if expect_only_error else ""} '
+                     f'but received: {resp_code}.')
+      else:
+        logger.info(f'Received HTTP status code of {resp_code} is acceptable '
+                    f'(expected 2XX{" or 400" if expect_only_error else ""}).')
 
       # Ensure response can be decoded as JSON
       try:
@@ -354,12 +366,25 @@ def main():
         results.add_result(test_name, TestResult.SKIPPED)
         continue
 
+      # If HTTP 400 was received, check that it is permitted (i.e., no SDI SUCCESS codes inside)
+      # (Note: SDI SUCCESS with HTTP 400 is a contradiction per WINNF-TS-3007 V1.2.0 (Sec 6.3.5))
+      if resp_code == 400 and any(resp.response.responseCode == ResponseCode.SUCCESS.value
+                                  for resp in response_obj.availableSpectrumInquiryResponses):
+        logger.error('Response message contains successful responses, but was delivered with HTTP '
+                     'status code 400 (BAD_REQUEST).')
+        http_code_mismatch = True
+
       # Compare response to mask
       logger.debug('Comparing response to mask...')
       try:
         if mask_runner.run_test_response_message(mask_obj, response_obj, validate_objects=False):
-          logger.info('Response meets mask requirements. Result EXPECTED.\n')
-          results.add_result(test_name, TestResult.EXPECTED)
+          if http_code_mismatch:
+            logger.error('Response content meets mask requirements, but HTTP status code is not '
+                         'valid (see prior error). Result UNEXPECTED.\n')
+            results.add_result(test_name, TestResult.UNEXPECTED)
+          else:
+            logger.info('Response meets mask requirements. Result EXPECTED.\n')
+            results.add_result(test_name, TestResult.EXPECTED)
         else:
           logger.error('Response does not meet mask requirements. Result UNEXPECTED.\n')
           results.add_result(test_name, TestResult.UNEXPECTED)


### PR DESCRIPTION
UPDATE: Based on additional feedback, this PR has been revised to only permit HTTP code 400 if all provided responses indicate an error and warn on instances where a mixture of valid/invalid requests are provided in a single request message. Revised PR notes are provided in the comments below.

Original PR Description:

> SDI is ambiguous on HTTP status code for many cases. Specifically, it's unclear what the status code should be if the response message contains any responses that indicate a non-SUCCESS code.
> 
> Originally, this harness assumed that a 2XX HTTP code would be returned for any response that did not meet one of the explicit criteria listed in the SDI (missing HTTP headers, bad URL, missing SDI message). However, it was requested that an AFC be permitted to return a 400 HTTP status code (BAD REQUEST) alongside any non-SUCCESS SDI response codes.
> 
> Note that as multiple requests may be addressed in a single response message, an HTTP status code of 400 is not sufficient to determine if a given request contains an error or not--the individual SDI response code would still need to be validated on a per-request basis. However, this harness assumes that an HTTP code of 400 must be accompanied by at least one non-SUCCESS SDI response code.
> 
> For example, if an AFC response satisfies a mask that expects only SUCCESS codes, but the AFC response includes any non-2XX HTTP status code, then the test result will still be UNEXPECTED. If an AFC response satisfies a mask that expects any non-SUCCESS code, then the harness will accept 2XX or 400 as the HTTP status code for an EXPECTED result.
> 
> This commit also fixes a typo in the masks directory README and adjusts some of the log messages in test_main (either typo fixes or adjustments for new HTTP code handling).