### PR TITLE
Update antenna model, diameter, gain data

### DIFF
--- a/data/common_data/README.md
+++ b/data/common_data/README.md
@@ -47,9 +47,9 @@ A description of each data repository is provided in [WINNF-TS-5008](https://6gh
    1. None
 
 ### <a name="antenna-gain-diameter"></a>Antenna Model, Diameter and Gain
- * Current version: [v1.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/antenna_model_diameter_gain.csv) - Used for Initial Certification (Published: 1-25-2023) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/81c1091e7ebed865c4a88d6687e449db20053cd1)]
+ * Current version: [v2.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/antenna_model_diameter_gain.csv) - Additional entries and modifications (Published: 4-1-2025) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/485341ee87db6da3eb23ae1984591d840d1fd0fa)]
  * Previous versions:
-   1. None
+   1. [v1.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/81c1091e7ebed865c4a88d6687e449db20053cd1/data/common_data/antenna_model_diameter_gain.csv) - Used for Initial Certification (Published: 1-25-2023) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/81c1091e7ebed865c4a88d6687e449db20053cd1)]
 
 ### <a name="transmit-radio"></a>Transmit Radio Unit Architecture
  * Current version: [v1.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/transmit_radio_unit_architecture.csv) - Used for Initial Certification (Published: 2-23-2023) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/867b484a55d92f283c8ea188ad506921b40bdc6c)]

--- a/data/common_data/README.md
+++ b/data/common_data/README.md
@@ -1,1 +1,57 @@
-Common Files used in the 6GHz AFC specification documents
+# 6 GHz Supplementary Data Repositories
+## Related Standard
+This repository contains the supplemental data repositories for 6 GHz AFC operation defined in [WINNF-TS-5008](https://6ghz.wirelessinnovation.org/baseline-standards).
+
+## Notifications
+To receive notifications of when a data repository in this directory is updated, consider using a [file watcher service](https://app.github-file-watcher.com/) to monitor [this GitHub repository](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC) GitHub repository and the `data/common_data/*` subdirectory. Additionally, modifications to these data repositories will be made via pull requests submitted to this GitHub repository.
+
+## Published Data Repositories
+A description of each data repository is provided in [WINNF-TS-5008](https://6ghz.wirelessinnovation.org/baseline-standards). Links to the version information for each data repository are provided below:
+ * [FCC Category B1 Antenna Models](#category-b1)
+ * [High Performance Antenna Models](#high-perf)
+ * [Indoor Unit Models](#indoor-units) [Deprecated]
+ * [FCC Fixed Service Channelization](#fs-channel)
+ * [Billboard Reflector Data](#billboard)
+ * [Back-to-back Antenna Data](#back-to-back)
+ * [Antenna Model, Diameter and Gain](#antenna-gain-diameter)
+ * [Transmit Radio Unit Architecture](#transmit-radio)
+
+### <a name="category-b1"></a> FCC Category B1 Antenna Models
+ * Current version: [v1.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/category_b1_antennas.csv) - Used for Initial Certification (Published: 3-9-2022) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/43d2bb9ea04f0e5fb5c77834a867a39af796a0b7)]
+ * Previous versions:
+   1. None
+
+### <a name="high-perf"></a> High Performance Antenna Models
+ * Current version: [v1.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/high_performance_antennas.csv) - Used for Initial Certification (Published: 3-9-2022) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/43d2bb9ea04f0e5fb5c77834a867a39af796a0b7)]
+ * Previous versions:
+   1. None
+
+### <a name="indoor-units"></a> Indoor Unit Models
+ * Current version: None [Deprecated] - Refer to [Transmit Radio Unit Architecture](#transmit-radio) instead (Deprecated on: 2-1-2023) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/867b484a55d92f283c8ea188ad506921b40bdc6c)]
+ * Previous versions:
+   1. [v0.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/indoor_unit_radios.csv) - Superseded by Transmit Radio Unit Architecture repository (Published: 3-21-2022) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/38acf8ccdd8d71257e0c0006d76aa08f80dd251a)]
+
+### <a name="fs-channel"></a> FCC Fixed Service Channelization
+ * Current version: [v1.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/fcc_fixed_service_channelization.csv) - Used for Initial Certification (Published: 3-23-2022) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/7aa4c997015ba855cc9e6dd1e3cb84de35dc4359)]
+ * Previous versions:
+   1. None
+
+### <a name="billboard"></a> Billboard Reflector Data
+ * Current version: [v1.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/billboard_reflector.csv) - Used for Initial Certification (Published: 8-10-2022) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/61f2f23e71baa1faac3560652ce808d7d24936d1)]
+ * Previous versions:
+   1. None
+
+### <a name="back-to-back"></a> Back-to-back Antenna Data
+ * Current version: [v1.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/back-to-back_antenna.csv) - Used for Initial Certification (Published: 8-10-2022) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/78b4771f0ae48ef8993060db2cf4794559372d45)]
+ * Previous versions:
+   1. None
+
+### <a name="antenna-gain-diameter"></a>Antenna Model, Diameter and Gain
+ * Current version: [v1.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/antenna_model_diameter_gain.csv) - Used for Initial Certification (Published: 1-25-2023) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/81c1091e7ebed865c4a88d6687e449db20053cd1)]
+ * Previous versions:
+   1. None
+
+### <a name="transmit-radio"></a>Transmit Radio Unit Architecture
+ * Current version: [v1.0](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/blob/main/data/common_data/transmit_radio_unit_architecture.csv) - Used for Initial Certification (Published: 2-23-2023) [[commit](https://github.com/Wireless-Innovation-Forum/6-GHz-AFC/commit/867b484a55d92f283c8ea188ad506921b40bdc6c)]
+ * Previous versions:
+   1. None

--- a/data/common_data/antenna_model_diameter_gain.csv
+++ b/data/common_data/antenna_model_diameter_gain.csv
@@ -1,10 +1,94 @@
 manufacturer,antennaModel,standardModel,diameter_ft,diameter_m,gain_dBi,notes
+ANDREW CORPORATION,5925,5925,,,,Indeterminate. 
+DECIBEL,12006,12006,,,,Indeterminate
+PRODELIN CORPORATION,139-702,139702,8,2.44,41.3,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,140-702,140702,10,3.05,43.2,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,153-742,153742,6,1.83,38.9,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,154-700,154700,8,2.44,41.5,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,154-740,154740,8,2.44,41.3,Comsearch's Frequency Coordination Database
+PRODELIN CORP.,154-742,154742,8,2.44,41.3,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,154-743,154743,8,2.44,41.3,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,155-742,155742,10,3.05,43.1,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,155-743,155743,10,3.05,43.1,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,156-702,156702,12,3.66,44.5,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,156-706,156706,12,3.66,44.8,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,163-740,163740,6,1.83,39.8,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,163-741,163741,6,1.83,39.8,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,164-700,164700,8,2.44,42.3,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,164-702,164702,8,2.44,42.1,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,164-740,164740,8,2.44,42.3,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,164-741,164741,8,2.44,42.5,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,164-743,164743,8,2.44,42,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,165-700,165700,10,3.05,44.1,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,165-740,165740,10,3.05,44,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,165-741,165741,10,3.05,44,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,166-700,166700,12,3.66,45.7,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,"153-742,743",153742743,6,1.83,38.9,Comsearch's Frequency Coordination Database
+PRODELIN INC,164-740741,164740741,8,2.44,42.5,Comsearch Frequency Coordination Database.  Higher of 740 and 741. 
+Prodelin,164-742743,164742743,8,2.44,42,Comsearch Frequency Coordination Database.
 MOTOROLA,85009294001,85009294001,6,1.83,38.2,https://www.winncom.com/pdf/Motorola_PTP800_Antennas_6/Motorola_PTP800_Antennas_6.pdf
 MOTOROLA,85009294002,85009294002,8,2.44,40.8,https://www.winncom.com/pdf/Motorola_PTP800_Antennas_6/Motorola_PTP800_Antennas_6.pdf
+"Cambium Networks, LTD",85009298001,85009298001,3,0.91,33,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85009298001,85009298001,3,0.91,33.3,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85009302001,85009302001,3,0.91,33,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85009302001,85009302001,3,0.91,33.3,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85009302003,85009302003,6,1.83,39,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85009328001,85009328001,4,1.22,35,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85010089003,85010089003,2.6,0.79,,11 GHz Antenna
 MOTOROLA,85010089021,85010089021,6,1.83,39,https://www.winncom.com/pdf/Motorola_PTP800_Antennas_6/Motorola_PTP800_Antennas_6.pdf
+"Cambium Networks, LTD",85010089050,85010089050,4,1.22,35,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85010089050,85010089050,4,1.22,35.5,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85010089052,85010089052,4,1.22,,11 GHz Antenna
 MOTOROLA,85010091006,85010091006,4,1.22,35,https://www.winncom.com/pdf/Motorola_PTP800_Antennas_6/Motorola_PTP800_Antennas_6.pdf
 MOTOROLA,85010091007,85010091007,6,1.83,39,https://www.winncom.com/pdf/Motorola_PTP800_Antennas_6/Motorola_PTP800_Antennas_6.pdf
+"Cambium Networks, LTD",85010091022,85010091022,3,0.91,33,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85010091022,85010091022,3,0.91,33.3,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85010091024,85010091024,4,1.22,35,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85010091024,85010091024,4,1.22,35.5,Comsearch's Frequency Coordination Database
 MOTOROLA,85010092021,85010092021,6,1.83,39,https://www.winncom.com/pdf/Motorola_PTP800_Antennas_6/Motorola_PTP800_Antennas_6.pdf
+"Cambium Networks, LTD",85010092048,85010092048,3,0.91,33,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85010092048,85010092048,3,0.91,33.3,Comsearch's Frequency Coordination Database
+CAMBIUM NETWORKS,1060082D128A,1060082D128A,3,0.91,33,Reference N060082D128A
+ANDREW,10-65C,1065C,10,3.05,,No Prefix.  Size 10 ft. 
+PRODELIN CORPORATION,153-706 RF,153706RF,6,1.83,38.8,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,154-706 LF,154706LF,8,2.44,41.3,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,154-706 RF,154706RF,8,2.44,41.3,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,155-706 LF,155706LF,10,3.05,43.2,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,155-706 RF,155706RF,10,3.05,43.2,Comsearch's Frequency Coordination Database
+PRODELIN CORPORATION,156-706 (RF),156706RF,12,3.66,44.8,Comsearch's Frequency Coordination Database
+ERICSSON,2422013DC12_R3,2422013DC12R3,8,2.44,41.6,Comsearch Frequency Coordination Database / UKY 220 13/DC12 R3X
+COMMSCOPE,41729A,41729A,6,1.83,38.8,Antenna Code for UHX6-59L RF
+ANDREW CORPORATION,41730A,41730A,6,1.83,38.8,Antenna Code for UHX6-59K LF
+Andrew,42480A,42480A,6,1.83,38.7,Antenna Code for PAR6-59W RF
+Andrew Corporation,46659A,46659A,6,1.83,38.8,Antenna Code for HPX6-59G
+RFS,51110C,51110C,6,1.83,39.8,Antenna Code for DA6-65B
+Commscope,51290A,51290A,6,1.83,38.8,Antenna Code for PAR6-65A RF
+RFS,53002C,53002C,6,1.83,39.6,Comsearch Frequency Coordination Database.
+RFS,54001C,54001C,8,2.44,42.1,Comsearch Frequency Coordination Database.
+Andrew,54449A,54449A,8,2.44,42,Antenna Code for PL8-59WB
+ERICSSON,6200/TRX3B/06SA/567/060/1,6200TRX3B06SA5670601,,,,Radio - Indeterminate. 
+Ericsson,6363/6LA1/30/256MA200,63636LA130256MA200,,,,Radio - Indeterminate. 
+ERICSSON,6363-6LA1-30-A40-296,63636LA130A40296,,,,Radio - Indeterminate. 
+NOKIA,6363-6LA1-30-A40-296,63636LA130A40296,,,,Radio - Indeterminate. 
+ERICSSON,666L-2XAAA-030-40-296,666L2XAAA03040296,,,,Radio - Indeterminate. 
+Ericsson,666L-63AAA-060-B7B,666L63AAA060B7B,,,,Radio - Indeterminate. 
+DRAGONWAVE INC,6LES60HFC500V01,6LES60HFC500V01,,,,Radio - Indeterminate. 
+DragonWave,6LQD30HFC200v03,6LQD30HFC200V03,,,,Radio - Indeterminate. 
+"Cambium Networks, LTD",85009294001 LF,85009294001LF,6,1.83,38.7,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85009294001 RF,85009294001RF,6,1.83,38.7,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85009294002 LF,85009294002LF,8,2.44,41,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85009294002 RF,85009294002RF,8,2.44,41,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",85009294003 LF,85009294003LF,10,3.05,43.4,Comsearch's Frequency Coordination Database
+PERISCOPE,8 FT/10X15 REFL,8FT10X15REFL,8,2.44,40.1,"Comsearch's Frequency Coordination Database, Set diameter to 8 ft to match antenna on the ground. "
+COMMSCOPE,95MPR61-C128F30-163,95MPR61C128F30163,,,,Radio - Indeterminate. 
+"Alcatel?Lucent USA, Inc.",95MPR61?H128F30?160,95MPR61H128F30160,,,,Radio - Indeterminate. 
+Nokia,95MPR61-L1024A30-227,95MPR61L1024A30227,,,,Radio - Indeterminate. 
+"Alcatel-Lucent USA, Inc.",95MPR61-L1024A30-227-SACM,95MPR61L1024A30227SACM,,,,Radio - Indeterminate. 
+ANDREW CORPORATION,95MPR61-L256F30-183,95MPR61L256F30183,,,,Radio - Indeterminate. 
+"Alcatel Lucent USA, Inc.",95MPR67-L1024A10-72-HACM,95MPR67L1024A1072HACM,,,,Radio - Indeterminate. 
+HUAWEI,A06S18HAC,A06S18HAC,6,1.83,39.4,Comsearch's Frequency Coordination Database
+Andrew Corporation,A64130,A64130,8,2.44,42.3,Antenna Code for P8-65D
+DRAGONWAVE,A-AN-06G-96-W-A,AAN06G96WA,8,2.44,41.9,https://www.scribd.com/document/348184480/Andrew-Antenna-Specs
 DRAGONWAVE,A-ANG-6G-6,AANG6G6,6,1.83,38.9,https://www.talleycom.com/static/pdf/A-ANT-18G-72-C.pdf
 DRAGONWAVE,A-ANT-06G-36-C-A,AANT06G36CA,3,0.91,33,https://www.scribd.com/document/348184480/Andrew-Antenna-Specs
 DRAGONWAVE,A-ANT-06G-48-C-A,AANT06G48CA,4,1.22,35,https://www.scribd.com/document/348184480/Andrew-Antenna-Specs
@@ -27,45 +111,120 @@ DRAGONWAVE,A-ANT-U6G-72,AANTU6G72,6,1.83,39.8,https://www.scribd.com/document/34
 DRAGONWAVE,A-ANT-U6G-72-C,AANTU6G72C,6,1.83,39.8,https://www.scribd.com/document/348184480/Andrew-Antenna-Specs
 DRAGONWAVE,A-ANT-U6G-72-C-A,AANTU6G72CA,6,1.83,39.8,https://www.scribd.com/document/348184480/Andrew-Antenna-Specs
 DRAGONWAVE,A-ANY-06G-48-C-A,AANY06G48CA,4,1.22,35,https://www.scribd.com/document/348184480/Andrew-Antenna-Specs
-TRANGO,AD6G-3,AD6G3,3.35,1.02,32.5,https://www.gotrango.com/wp-content/uploads/support/documents/datasheets/DS-1001_Rev_D_Trango-Antenna.pdf
-TRANGO,AD6G-3T2,AD6G3T2,3.35,1.02,32.5,https://www.gotrango.com/wp-content/uploads/support/documents/datasheets/DS-1001_Rev_D_Trango-Antenna.pdf
-TRANGO,AD6G-3-T2,AD6G3T2,3.35,1.02,32.5,https://www.gotrango.com/wp-content/uploads/support/documents/datasheets/DS-1001_Rev_D_Trango-Antenna.pdf
+TRANGO,AD6G-3,AD6G3,3,0.91,32.5,https://www.gotrango.com/wp-content/uploads/support/documents/datasheets/DS-1001_Rev_D_Trango-Antenna.pdf
+"Trango Networks, LLC",AD6G-3-S2-V2,AD6G3S2V2,3,0.91,33.3,Comsearch's Frequency Coordination Database
+TRANGO,AD6G-3T2,AD6G3T2,3,0.91,32.5,https://www.gotrango.com/wp-content/uploads/support/documents/datasheets/DS-1001_Rev_D_Trango-Antenna.pdf
+TRANGO,AD6G-3-T2,AD6G3T2,3,0.91,32.5,https://www.gotrango.com/wp-content/uploads/support/documents/datasheets/DS-1001_Rev_D_Trango-Antenna.pdf
+TRANGO NETWORKS,AD6G-4-S2,AD6G4S2,4,1.3,35.6,Comsearch's Frequency Coordination Database
+"Trango Networks, LLC",AD6G-4-S2-V2,AD6G4S2V2,4,1.3,35.6,Comsearch's Frequency Coordination Database
 TRANGO,AD6G-4-T2,AD6G4T2,4,1.22,35.6,https://www.gotrango.com/wp-content/uploads/support/documents/datasheets/DS-1001_Rev_D_Trango-Antenna.pdf
+"Trango Networks, LLC",AD6G-6-S2-V2,AD6G6S2V2,6,1.83,39.4,Comsearch's Frequency Coordination Database
 TRANGO,AD6G-6-T2,AD6G6T2,6,1.83,39.4,https://www.gotrango.com/wp-content/uploads/support/documents/datasheets/DS-1001_Rev_D_Trango-Antenna.pdf
 TRANGO,AD6G-6-T2CATA,AD6G6T2CATA,6,1.83,39.4,https://www.gotrango.com/wp-content/uploads/support/documents/datasheets/DS-1001_Rev_D_Trango-Antenna.pdf
+TRANGO NETWORKS,AD6G-8-S2-D-UDR70,AD6G8S2DUDR70,8,2.4,41.9,Comsearch's Frequency Coordination Database
 TRANGO,AD6GU-8-T2,AD6GU8T2,8,2.44,42,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,ADP10V-59 DIV LF,ADP10V59DIVLF,10,3.05,42.9,Comsearch's Frequency Coordination Database
+Rockwell International,AJN9UO-8803,AJN9UO8803,,,,Radio - Indeterminate. 
 ALCOMA,AL3-6,AL36,3,0.91,33.1,http://www.al-wireless.com/media/document/brochure-en-al3-06mpr-130301.pdf
 ALCOMA,AL3-6/MPR,AL36MPR,3,0.91,33.1,http://www.al-wireless.com/media/document/brochure-en-al3-06mpr-130301.pdf
 ALCOMA,AL3-6_MPR,AL36MPR,3,0.91,33.1,http://www.al-wireless.com/media/document/brochure-en-al3-06mpr-130301.pdf
 ALCOMA,AL4-6/MPR,AL46MPR,4,1.22,35.6,http://www.al-wireless.com/media/document/brochure-en-al4-06mpr-130301.pdf
 HUAWEI,AL6D24HS,AL6D24HS,8,2.44,41,https://fccid.io/ANATEL/03790-14-03257/AL6D24HS/C830E611-6064-4969-9403-B4F0A121FE9B/PDF
+SIAE MICROELETTRONICA,ALF06U-PLUS1-255M 4096QAM,ALF06UPLUS1255M4096QAM,,,,Radio - Indeterminate. 
 CERAGON,AM-3-6-A,AM36A,3,0.91,33.5,https://www.sicetelecom.it/wp-content/MU/datasheet/Ceragon-Ceragon-Antennas-Parabola-90cm-11GHz-perDISH90-11-C2-SC-SICE-Distributore-Italiano.pdf
 CERAGON,AM-4-6-A,AM46A,4,1.22,35.8,https://www.sociustechnology.com.au/WebRoot/ecshared01/Shops/sociustec/57E4/CD3A/D46A/003C/50E6/AC10/003F/EB59/Ceragon_am-4-freq-circ-cr1_doc-00049561_reva_00.pdf
 CERAGON,AM-4-6-R,AM46R,4,1.22,35.8,https://www.sociustechnology.com.au/WebRoot/ecshared01/Shops/sociustec/57E4/CD3A/D46A/003C/50E6/AC10/003F/EB59/Ceragon_am-4-freq-circ-cr1_doc-00049561_reva_00.pdf
 CERAGON,AM-4-6-RW,AM46RW,4,1.22,36.5,https://www.sociustechnology.com.au/WebRoot/ecshared01/Shops/sociustec/57E4/CD3A/D46A/003C/50E6/AC10/003F/EB59/Ceragon_am-4-freq-circ-cr1_doc-00049561_reva_00.pdf
+Ceragon Networks,AM-6-6-RW,AM66RW,6,1.83,39.3,Comsearch's Frequency Coordination Database
+Andrew,Andrew,ANDREW,,,,Indeterminate. 
+Andrew Corp.,Andrew Corp.,ANDREWCORP,,,,Indeterminate.
+GABRIEL ELECTRONICS,ANDREW CORPORATION,ANDREWCORPORATION,,,,Indeterminate. 
+UHX8-59J R,ANDREW CORPORATIONANDREW,ANDREWCORPORATIONANDREW,,,,Indeterminate. 
+Andrew Corp,Andrew PAR6-65A RF,ANDREWPAR665ARF,6,1.83,38.8,Used PAR6-65A RF
+Andrew Corp,Andrew PL6-65G,ANDREWPL665G,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
+Ericsson,ANT0/0 B 1.8 6/11 HPX/HPX,ANT00B18611HPXHPX,6,1.8,39.3,Same as UKY 230 46/GD41H.  Comsearch's Frequency Coordination Database
 ERICSSON,ANT0 1.2 6L HPX,ANT0126LHPX,4,1.22,35.8,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,ANT01.26UHPX,ANT0126UHPX,4,1.22,35.8,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,ANT0 1.8 6L HPX,ANT0186LHPX,6,1.83,39.3,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,ANT0 2.4 6L HPX,ANT0246LHPX,8,2.44,42.1,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,ANT0 2.4 6U HPX,ANT0246UHPX,8,2.44,42.1,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
+"SIAE Microelettronica, In",ANT-06GHZ-72-CIR,ANT06GHZ72CIR,6,1.83,39.4,Comsearch's Frequency Coordination Database
+ERICSSON,ANT0 A 1.8 6L HPX,ANT0A186LHPX,6,1.83,38.6,"Comsearch, via Manufacturer's NSMA file"
+ERICSSON,ANT0 A 2.4 6 HPX,ANT0A246HPX,8,2.44,41.6,"Comsearch, via Manufacturer's NSMA file"
+ERICSSON,ANT0 A 2.4 6L HPX,ANT0A246LHPX,8,2.44,42.1,Comsearch's Frequency Coordination Database
+ERICSSON,ANT0 A 2.4 6U HPX,ANT0A246UHPX,8,2.44,41.9,"Comsearch, via Manufacturer's NSMA file"
+ERICSSON,ANT0 A 3.0 6 HPX,ANT0A306HPX,10,3.05,43.2,"Comsearch, via Manufacturer's NSMA file"
 ERICSSON,ANT0B3.06LHPX,ANT0B306LHPX,10,3.05,43.5,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,ANT2 1.2 6L HPX,ANT2126LHPX,4,1.22,35.8,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,ANT2 1.8 6L HP,ANT2186LHP,6,1.83,39.3,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,ANT2 1.8 6L HPX,ANT2186LHPX,6,1.83,39.3,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,ANT2 1.8 6U HPX,ANT2186UHPX,6,1.83,39.3,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
+ERICSSON,ANT2A0.96UHPX,ANT2A096UHPX,3,0.91,33.3,Assumed to be ANT2 A 0.9 6 HPX  which is  BFZ 622 33/2D01H           
 Ericsson,ANT2 A 1.8 6L HPX,ANT2A186LHPX,6,1.83,39.3,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
+Ericsson,ANT3 A 0.9 6 HPX,ANT3A096HPX,3,0.91,32.5,Comsearch: Reference BFZ 622 33/3D01H / ANT3 A 0.9 6L HPX
+ERICSSON,ANT3 A 1.2 6 HPX,ANT3A126HPX,4,1.22,34.8,Comsearch's Frequency Coordination Database
 ERICSSON,ANT3 A 1.2 6L HP,ANT3A126LHP,4,1.22,35.8,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,ANT3_A_1.2_6L_HP,ANT3A126LHP,4,1.22,35.8,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
+ERICSSON,ANT3 A 1.8 6 HPX,ANT3A186HPX,6,1.83,39.1,Comsearch's Frequency Coordination Database
 ERICSSON,ANT3 A 1.8 6L HP,ANT3A186LHP,6,1.83,39.3,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,ANT3_A_1.8_6L_HP,ANT3A186LHP,6,1.83,39.3,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
+ERICSSON,ANT3 A 1.8 6L HPX,ANT3A186LHPX,6,1.83,38.6,"Comsearch, via Manufacturer's NSMA file"
+Commscope,APR^-65A RF,APR65ARF,,,,Indeterminate. 
+Andrew Corporation,APR8-59A,APR859A,8,2.44,40.8,Used PAR8-59A
 ARC WIRELESS,ARC-UHP-MW-6-4,ARCUHPMW64,4,1.22,36.2,Comsearch's Frequency Coordination Database
+"SIAE MICROELETTRONICA, IN",ASNKDDC6U-AGS20_256M ACN,ASNKDDC6UAGS20256MACN,,,,Radio - Indeterminate. 
+"SIAE MICROELETTRONICA, IN",ASNKDDC6U-AGS20_64M ACM,ASNKDDC6UAGS2064MACM,,,,Radio - Indeterminate. 
+SIAE Microelettronica,ASNKDSC6U-AGS20-30M,ASNKDSC6UAGS2030M,,,,Radio - Indeterminate. 
+SIAE Microelettronica,ASNKDSC6U-AGS20-30M-,ASNKDSC6UAGS2030M,,,,Radio - Indeterminate. 
+SIAE Microelettronica,ASNKHP6U-AGS20-28M,ASNKHP6UAGS2028M,,,,Radio - Indeterminate. 
+GABRIEL ELECTRONICS,ATH-10,ATH10,10,3.05,42.6,Comsearch's Frequency Coordination Database
 HUAWEI,AU6D24HS,AU6D24HS,8,2.44,41.8,https://fccid.io/ANATEL/03789-14-03257/AU6D24HS/87065A42-DA7D-402F-AD09-25D5F1505FBD/PDF
+RFS,Bald Knob,BALDKNOB,,,,Indeterminate. 
+HARRIS CORPORATION,BCK9GKDVM6-16T-1,BCK9GKDVM616T1,,,,Radio - Indeterminate. 
+Harris Corporation,BCK9GKDVM6-4564-1,BCK9GKDVM645641,,,,Radio - Indeterminate. 
+HARRIS CORPORATION,BCK9GKDVM6-8T-5,BCK9GKDVM68T5,,,,Radio - Indeterminate. 
+HARRIS,BCK9GKMSTR0630-1,BCK9GKMSTR06301,,,,Radio - Indeterminate. 
+ERICSSON,BFZ 622 33/3D01H,BFZ622333D01H,3,0.9,32.517,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 33/3S01H,BFZ622333S01H,3,0.91,32.717,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 34/0D01H,BFZ622340D01H,4,1.22,34.4,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 34/2D01H,BFZ622342D01H,4,1.22,34.4,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 34/2S01H,BFZ622342S01H,4,1.22,34.42,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 34/3D01H,BFZ622343D01H,4,1.22,34.8,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 34/3S01H,BFZ622343S01H,4,1.22,34.4,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 34/3S01H,BFZ622343S01H,4,1.22,35.4,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 34/3S01H,BFZ622343S01H,4,1.22,35,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 35/0D01H,BFZ622350D01H,6,1.83,38.8,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 35/0D01H,BFZ622350D01H,6,1.83,39.1,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 35/2D01H,BFZ622352D01H,6,1.83,38.6,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 35/2D01H,BFZ622352D01H,6,1.83,39.6,comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 35/2S01H,BFZ622352S01H,6,1.83,39.6,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 35/2S01H,BFZ622352S01H,6,1.83,38.8,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 35/3D01H,BFZ622353D01H,6,1.83,38.63,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 35/3D01H,BFZ622353D01H,6,1.83,39.43,comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 35/3S01H,BFZ622353S01H,6,1.83,38.8,comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 54/3D01H,BFZ622543D01H,4,1.22,35.7,Comsearch's Frequency Coordination Database
 Ericsson,BFZ 622 55/3D01H,BFZ622553D01H,6,1.83,39.3,http://storage.mtender.gov.md/get/f7291f5a-ceb2-4ed0-a95d-d47694abcbe0-1570511924257
-Radio Frequency Systems,DA 10-59,DA1059,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/DA10-59AD
+ERICSSON,BFZ 622 74/3D01H,BFZ622743D01H,4,1.22,35.6,Comsearch's Frequency Coordination Database
+ERICSSON,BFZ 622 74/3D01H,BFZ622743D01H,4,1.22,34.85,Comsearch's Frequency Coordination Database
+Harris,Cablewave,CABLEWAVE,,,,Indeterminate.
+ANDREW CORPORATION,CABLEWAVE SYSTEMS,CABLEWAVESYSTEMS,,,,Indeterminate. 
+SAF Tehnika,CFIP Lumina 6,CFIPLUMINA6,,,,Radio - Indeterminate. 
+ANT FOR COMM,CH-10,CH10,10,3.05,43.5,Comsearch's Frequency Coordination Database
+ANT FOR COMM,CH-10E,CH10E,10,3.05,43.5,Comsearch's Frequency Coordination Database
+ANT FOR COMM,CH-7,CH7,7,2.13,40.4,Comsearch's Frequency Coordination Database
+ANT FOR COMM,CH-8,CH8,8,2.44,41.6,Comsearch's Frequency Coordination Database
+Commscope,COMMSCOPE,COMMSCOPE,,,,Indeterminate. 
+Commscope,Commscope Commscope,COMMSCOPECOMMSCOPE,,,,Indeterminate. 
+Andrew,Corporation,CORPORATION,,,,Indeterminate. 
+AVIAT NETWORKS,CTE6V2HL630M180 ACM,CTE6V2HL630M180ACM,,,,Radio - Indeterminate. 
+Commscope,D8E-3,D8E3,,,,Indeterminate. 
+RFS,DA10,DA10,10,3.05,,10 foot antenna. Various bands have gain range of 43.4 - 44.6
+RFS,DA10-58W,DA1058W,10,3.05,43.6,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,DA10 59,DA1059,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/DA10-59AD
 CABLEWAVE SYSTEMS,DA10.59,DA1059,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/DA10-59AD
-RFS,DA10?59,DA1059,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/DA10-59AC
 CABLEWAVE SYSTEMS,DA10-59,DA1059,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/DA10-59AD
+Radio Frequency Systems,DA 10-59,DA1059,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/DA10-59AD
+RFS,DA10?59,DA1059,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/DA10-59AC
 RFS,DA10-59,DA1059,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/DA10-59AC
 RFS,DA10-59A,DA1059A,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/DA10-59AC
 CABLEWAVE SYSTEMS,DA10-59AC,DA1059AC,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/DA10-59AC
@@ -85,6 +244,7 @@ RFS,DA12-59A,DA1259A,12,3.66,45.1,https://www.rfsworld.com/pim/product/html/DA12
 CABLEWAVE SYSTEMS,DA12 65,DA1265,12,3.66,45.8,https://www.rfsworld.com/pim/product/html/DA12-65AC
 CABLEWAVE SYSTEMS,DA12-65,DA1265,12,3.66,45.8,https://www.rfsworld.com/pim/product/html/DA12-65AC
 RFS,DA12-65A,DA1265A,12,3.66,45.8,https://www.rfsworld.com/pim/product/html/DA12-65AC
+CABLEWAVE SYSTEMS,DA15-65A,DA1565A,15,4.57,47.5,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,DA6-59,DA659,6,1.83,39,Comsearch's Frequency Coordination Database
 RFS,DA6-59,DA659,6,1.83,39,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,DA6-59A,DA659A,6,1.83,39,Comsearch's Frequency Coordination Database
@@ -105,11 +265,14 @@ RFS/Cablewave,DA6W57,DA6W57,6,1.83,39,https://www.rfsworld.com/pim/product/html/
 RFS,DA6-W578,DA6W578,6,1.83,39,https://www.rfsworld.com/pim/product/html/DA6-W57BC
 RFS,DA6-W57A,DA6W57A,6,1.83,39,https://www.rfsworld.com/pim/product/html/DA6-W57BC
 RFS,DA6-W57B,DA6W57B,6,1.83,39,https://www.rfsworld.com/pim/product/html/DA6-W57BC
+RFS,DA8,DA8,8,2.44,,8 foot antenna. Various bands have gain range of 41.3 - 42.8
 CABLEWAVE SYSTEMS,DA8-59,DA859,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/DA8-59AC
 RFS,DA8-59,DA859,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/DA8-59AC
 CABLEWAVE SYSTEMS,DA8-59A,DA859A,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/DA8-59AC
 RFS,DA8-59A,DA859A,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/DA8-59AC
 CABLEWAVE SYSTEMS,DA8-59AC,DA859AC,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/DA8-59AC
+RFS,DA8-59A(P),DA859AP,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/DA8-59AC
+COMMSCOPE,DA8-59ASHP-6W,DA859ASHP6W,8,2.44,41.6,Based on DA859A.  Not sure if this suffix is indicating an SHP diversity antenna?
 CABLEWAVE,DA8-59E,DA859E,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/DA8-59AC
 CABLEWAVE SYSTEMS,DA8-59WAC,DA859WAC,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/DA8-59AC
 RFS,DA8-59WAC,DA859WAC,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/DA8-59AC
@@ -120,6 +283,7 @@ RFS,DA8-65,DA865,8,2.44,42.3,https://www.rfsworld.com/pim/product/html/DA8-65AC
 RFS,DA8?65A,DA865A,8,2.44,42.3,https://www.rfsworld.com/pim/product/html/DA8-65AC
 RFS,DA8-65A,DA865A,8,2.44,42.3,https://www.rfsworld.com/pim/product/html/DA8-65AC
 CABLEWAVE SYSTEMS,DA8-65AC,DA865AC,8,2.44,42.3,https://www.rfsworld.com/pim/product/html/DA8-65AC
+Andrew,DA8-65L,DA865L,8,2.44,42.3,Based on DA865
 RFS,DA8-W57A,DA8W57A,8,2.44,41.5,https://www.rfsworld.com/pim/product/html/DA8-W57AC
 CABLEWAVE SYSTEMS,DAX10-59,DAX1059,10,3.05,43.2,https://www.rfsworld.com/pim/product/html/DAX10-59AC4
 RFS,DAX10-59,DAX1059,10,3.05,43.2,https://www.rfsworld.com/pim/product/html/DAX10-59AC
@@ -136,6 +300,7 @@ CABLEWAVE SYSTEMS,DAX12-59,DAX1259,12,3.66,44.8,https://www.rfsworld.com/pim/pro
 RFS,DAX12-59,DAX1259,12,3.66,44.8,https://www.rfsworld.com/pim/product/html/DAX12-59AC
 RFS,DAX12-59A,DAX1259A,12,3.66,44.8,https://www.rfsworld.com/pim/product/html/DAX12-59AC
 RFS,DAX12-W59,DAX12W59,12,3.66,44.8,http://www.dadehnama.ir/uploads/4_313508659575390274.pdf
+RFS,DAX-59,DAX59,,,,Indeterminate. 
 CABLEWAVE SYSTEMS,DAX6-59A,DAX659A,6,1.83,38.7,Comsearch's Frequency Coordination Database
 RFS,DAX6-59A,DAX659A,6,1.83,38.7,Comsearch's Frequency Coordination Database
 RFS,DAX6-59B,DAX659B,6,1.83,38.7,Comsearch's Frequency Coordination Database
@@ -146,15 +311,22 @@ RFS,DAX8-59,DAX859,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/DAX8-59
 CABLEWAVE SYSTEMS,DAX8-59A,DAX859A,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/DAX8-59AC
 RFS,DAX8-59A,DAX859A,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/DAX8-59AC
 RFS,DAX8-59W,DAX859W,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/DAX8-59AC
-RFS/Cablewave,DAX865,DAX865,8,2.44,42.2,https://www.rfsworld.com/pim/product/html/DAX8-65AC
 CABLEWAVE SYSTEMS,DAX8-65,DAX865,8,2.44,42.2,https://www.rfsworld.com/pim/product/html/DAX8-65AD
+RFS/Cablewave,DAX865,DAX865,8,2.44,42.2,https://www.rfsworld.com/pim/product/html/DAX8-65AC
 RFS,DAX8-65A,DAX865A,8,2.44,42.2,https://www.rfsworld.com/pim/product/html/DAX8-65AC
 RFS,DAX8-W59A,DAX8W59A,8,2.44,41.3,http://www.dadehnama.ir/uploads/4_313508659575390274.pdf
+Gabriel Electronics,DBFB6-64,DBFB664,6,1.83,39.5,Typo should be DRFB6-64. Using those specifications.  
+RFS,DBUX10-W60W103A_L,DBUX10W60W103AL,10,3.05,43.5,Comsearch's Frequency Coordination Database
 RFS,DBUX12-W60W103ACC,DBUX12W60W103ACC,12,3.66,45.1,https://www.rfsworld.com/pim/product/pdf/DBUX12-W60W103ACC
+RFS,DBUX12-W60W103A_L,DBUX12W60W103AL,12,3.66,45.1,Comsearch's Frequency Coordination Database
+RFS,DBUX12-W60W103A_U,DBUX12W60W103AU,12,3.66,,"Dual band antenna, suffix U indicates 11 GHz Antenna"
 RFS,DBUX6-W60W103A,DBUX6W60W103A,6,1.83,39.3,https://www.rfsworld.com/pim/product/pdf/DBUX6-W60W103ADB
 RFS,DBUX6-W60W103A_L,DBUX6W60W103AL,6,1.83,39.3,https://www.rfsworld.com/pim/product/pdf/DBUX6-W60W103ADB
+RFS,DBUX8-W60W103A,DBUX8W60W103A,8,2.44,41.7,Comsearch's Frequency Coordination Database
 RFS,DBUX8-W60W103ACC,DBUX8W60W103ACC,8,2.44,41.7,https://www.rfsworld.com/pim/product/pdf/DBUX8-W60W103ACC
 RFS,DBUX8-W60W103A_L,DBUX8W60W103AL,8,2.44,41.7,"https://www.rfsworld.com/images/sma/rpe/dbux8/dbux8-w60w103a_l%20(5.925-7.125),%2020201104.pdf"
+RFS,DBX6-W60W103ACC,DBX6W60W103ACC,6,1.83,39.3,Comsearch's Frequency Coordination Database
+RFS,DBX6-W60W103ACC_U,DBX6W60W103ACCU,6,1.83,,"Dual band antenna, suffix U indicates 11 GHz Antenna"
 RFS,DBX8-W60W103,DBX8W60W103,8,2.44,41.7,https://www.rfsworld.com/pim/product/pdf/DBUX8-W60W103ACC
 RFS,DBX8-W60W103ACC_L,DBX8W60W103ACCL,8,2.44,41.7,https://www.rfsworld.com/pim/product/pdf/DBUX8-W60W103ACC
 GABRIEL,DD10-64BSE,DD1064BSE,10,3.05,44,Comsearch's Frequency Coordination Database
@@ -167,12 +339,15 @@ GABRIEL,DD8-64BSE,DD864BSE,8,2.44,42.2,Comsearch's Frequency Coordination Databa
 GABRIEL,DD8-64DSE,DD864DSE,8,2.44,42,Comsearch's Frequency Coordination Database
 GABRIEL,DD8W-5971,DD8W5971,8,2.44,40.4,Comsearch's Frequency Coordination Database
 GABRIEL,DDP 10P-59BSE,DDP10P59BSE,10,3.05,43.1,Comsearch's Frequency Coordination Database
+"Gabriel Electronics, Inc.",DDP12P-59CSE,DDP12P59CSE,12,3.66,44.7,Comsearch's Frequency Coordination Database
+Gabriel Electronics,DDP-69-59CSE,DDP6959CSE,,,,Indeterminate. 
 Gabriel Electronics,DDP6P-59,DDP6P59,6,1.83,38.5,Comsearch's Frequency Coordination Database
 GABRIEL,DDP6P-59CSE,DDP6P59CSE,6,1.83,39,Comsearch's Frequency Coordination Database
 GABRIEL,DDP8P-59,DDP8P59,8,2.44,40.7,Comsearch's Frequency Coordination Database
 GABRIEL,DDP8P-59BSE,DDP8P59BSE,8,2.44,41.2,Comsearch's Frequency Coordination Database
 GABRIEL,DFB8-64ASE,DFB864ASE,8,2.44,42.3,Typo should be DRFB864ASE. Using that gain.
 GABRIEL,DFRB6-64,DFRB664,6,1.83,39.5,Typo should be DRFB664 using that gain
+GABRIEL ELECTRONICS,DP10P-1J23A,DP10P1J23A,10,3.05,42.8,Comsearch's Frequency Coordination Database
 RADIO WAVES,DP6-59,DP659,6,1.83,38.3,Comsearch's Frequency Coordination Database
 RADIO WAVES,DP6-64,DP664,6,1.83,38.8,Comsearch's Frequency Coordination Database
 GABRIEL,DP6P-1J23A,DP6P1J23A,6,1.83,38.79,Comsearch's Frequency Coordination Database
@@ -188,11 +363,13 @@ GABRIEL,DRFB10 64CSE,DRFB1064CSE,10,3.05,44,Comsearch's Frequency Coordination D
 GABRIEL,DRFB10-64CSE,DRFB1064CSE,10,3.05,44,Comsearch's Frequency Coordination Database
 GABRIEL,DRFB10P-59,DRFB10P59,10,3.05,42.9,Comsearch's Frequency Coordination Database
 GABRIEL,DRFB10W-5971,DRFB10W5971,10,3.05,43.6,Comsearch's Frequency Coordination Database
-Gabriel Electronics,DRFB12-59CSE,DRFB1259CSE,12,3.66,44.2,http://hpwren.ucsd.edu/SCI-5.8GHz-link/rss-57.pdf
+Gabriel Electronics,DRFB12-59CSE,DRFB1259CSE,12,3.66,44.8,http://hpwren.ucsd.edu/SCI-5.8GHz-link/rss-57.pdf (see Standard = A)
 GABRIEL,DRFB12-64,DRFB1264,12,3.66,45.5,Comsearch's Frequency Coordination Database
 GABRIEL,DRFB12-64A,DRFB1264A,12,3.66,45.5,Comsearch's Frequency Coordination Database
 GABRIEL,DRFB12-64BSE,DRFB1264BSE,12,3.66,45.5,Comsearch's Frequency Coordination Database
 ,DRFB4-59ASE,DRFB459ASE,4,1.22,34.7,http://hpwren.ucsd.edu/SCI-5.8GHz-link/rss-57.pdf
+GABRIEL ELECTRONICS,DRFB5-59BSE,DRFB559BSE,,,,Indeterminate. 
+GABRIEL ELECTRONIC,DRFB-64,DRFB64,,,,Indeterminate. 
 GABRIEL,DRFB6-5968SE,DRFB65968SE,6,1.83,38.9,Comsearch's Frequency Coordination Database
 RFS,DRFB6-5968SE,DRFB65968SE,6,1.83,38.9,Comsearch's Frequency Coordination Database
 GABRIEL,DRFB6-5971SE,DRFB65971SE,6,1.83,39.6,Comsearch's Frequency Coordination Database
@@ -212,6 +389,7 @@ GABRIEL,DRFB6-6A,DRFB66A,6,1.83,39.8,Typo should be DRFB664A. Using that gain.
 GABRIEL,DRFB6-6BSE,DRFB66BSE,6,1.83,40.1,Typo should be DRFB664BSE. Using that gain. 
 GABRIEL,DRFB6P-59,DRFB6P59,6,1.83,38.5,Comsearch's Frequency Coordination Database
 GABRIEL,DRFB6W-5971SE,DRFB6W5971SE,6,1.83,39.6,Comsearch's Frequency Coordination Database
+Gabriel Electronic,DRFB810-64CSE,DRFB81064CSE,,,,Indeterminate. 
 GABRIEL,DRFB8-5968SE,DRFB85968SE,8,2.44,41.4,Comsearch's Frequency Coordination Database
 GABRIEL,DRFB8-59ASE,DRFB859ASE,8,2.44,41,Comsearch's Frequency Coordination Database
 GABRIEL,DRFB8-59BSE,DRFB859BSE,8,2.44,41.3,Comsearch's Frequency Coordination Database
@@ -224,25 +402,43 @@ GABRIEL,DRFB8-64BSE,DRFB864BSE,8,2.44,42.3,Comsearch's Frequency Coordination Da
 GABRIEL,DRFB8 64CSE,DRFB864CSE,8,2.44,42.1,Comsearch's Frequency Coordination Database
 GABRIEL,DRFB8-64CSE,DRFB864CSE,8,2.44,42.1,Comsearch's Frequency Coordination Database
 GABRIEL,DRFB8P-59,DRFB8P59,8,2.44,41,Comsearch's Frequency Coordination Database
-GABRIEL,DRFB8-W-5971-P-RK,DRFB8W5971PRK,8,2.44,40.1,Comsearch's Frequency Coordination Database
-GABRIEL,DRFB8W-5971SE,DRFB8W5971SE,8,2.44,40.1,Comsearch's Frequency Coordination Database
-Commscope/Andrew,HDH1065,HDH1065,10,3.05,43.9,https://www.datasheets360.com/pdf/-476679127502020136
+GABRIEL,DRFB8-W-5971-P-RK,DRFB8W5971PRK,8,2.44,41.7,Comsearch's Frequency Coordination Database
+GABRIEL,DRFB8W-5971SE,DRFB8W5971SE,8,2.44,41.7,Comsearch's Frequency Coordination Database
+"Aviat Networks, Inc.",E300HPU6-10M 256Q 56MB,E300HPU610M256Q56MB,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,E600V2HPL6_10M 256Q 56M,E600V2HPL610M256Q56M,,,,Radio - Indeterminate. 
+Aviat Networks,E6HL660M454_R70 AMR,E6HL660M454R70AMR,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,E6HU630M227_R70,E6HU630M227R70,,,,Radio - Indeterminate. 
+EXALT COMMUNICATIONS INC.,E6LF84H-0252XY-512-60,E6LF84H0252XY51260,,,,Radio - Indeterminate. 
+Aviat Networks,E6v2HL610M73R70 ACM,E6V2HL610M73R70ACM,,,,Radio - Indeterminate. 
+Aviat Networks,E6v2HU630M267R7 ACM,E6V2HU630M267R7ACM,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",E6V2HU6-5M 256Q 27 R70,E6V2HU65M256Q27R70,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",E6V2SL6-60M,E6V2SL660M,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,E6v2spL6_30M ACM_R70_OC3,E6V2SPL630MACMR70OC3,,,,Radio - Indeterminate. 
+Digital Microwave,Eclipse,ECLIPSE,,,,Radio - Indeterminate. 
+ML6600/6365CA/06SA/364/03,ERICSSON,ERICSSON,,,,Radio - Indeterminate. 
+UKY 220 12/DC15 R3X,ERICSSON,ERICSSON,,,,Indeterminate. 
+Ceragon Networks,EVOLH-6-1024Q-30M-238MB,EVOLH61024Q30M238MB,,,,Radio - Indeterminate. 
+ALCATEL THOMSON FAISCEAUX HERTZIENS,FHA 046-3,FHA0463,10,3.05,43,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,GABRIEL ELECTRONICS,GABRIELELECTRONICS,,,,Indeterminate. 
+COMMSCOPE,H0X6-59K,H0X659K,6,1.83,38.8,Typo of HPX6-59K. 
+Commscope,H6X-6W,H6X6W,6,1.83,39.1,Typo of HX6-6W. 
 ANDREW,HDH10-65,HDH1065,10,3.05,43.9,https://www.datasheets360.com/pdf/-476679127502020136
+Commscope/Andrew,HDH1065,HDH1065,10,3.05,43.9,https://www.datasheets360.com/pdf/-476679127502020136
 COMMSCOPE,HDH10-65 MAIN,HDH1065MAIN,10,3.05,43.9,https://www.datasheets360.com/pdf/-476679127502020136
 Commscope/Andrew,HDH665,HDH665,6,1.83,39.7,https://www.datasheets360.com/pdf/-476679127502020136
-Commscope/Andrew,HDH865,HDH865,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
 ANDREW,HDH8-65,HDH865,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
+Commscope/Andrew,HDH865,HDH865,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
 ANDREW,HDH8-65 MAIN,HDH865MAIN,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
 COMMSCOPE,HDH8-65 MAIN,HDH865MAIN,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
 COMMSCOPE,HDH8-65 Main,HDH865MAIN,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
 RADIO WAVES,HDP6-59,HDP659,6,1.83,38.7,Typo should be HPD659. Using that gain.
 COMMSCOPE,HDV665,HDV665,6,1.83,39.7,https://www.datasheets360.com/pdf/-476679127502020136
-Commscope/Andrew,HDV665,HDV665,6,1.83,39.7,https://www.datasheets360.com/pdf/-476679127502020136
 COMMSCOPE,HDV6-65,HDV665,6,1.83,39.7,https://www.datasheets360.com/pdf/-476679127502020136
+Commscope/Andrew,HDV665,HDV665,6,1.83,39.7,https://www.datasheets360.com/pdf/-476679127502020136
 ANDREW,HDV6-65 MAIN,HDV665MAIN,6,1.83,39.7,https://www.datasheets360.com/pdf/-476679127502020136
+ANDREW,HDV8-65,HDV865,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
 COMMSCOPE,HDV865,HDV865,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
 Commscope/Andrew,HDV865,HDV865,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
-ANDREW,HDV8-65,HDV865,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
 ANDREW,HDV8-65 DIV,HDV865DIV,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
 ANDREW,HDV8-65 MAIN,HDV865MAIN,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
 COMMSCOPE,HDV8-65 MAIN,HDV865MAIN,8,2.44,42.4,https://www.datasheets360.com/pdf/-476679127502020136
@@ -258,8 +454,8 @@ ANDREW,HDX12-59 RF MAIN,HDX1259RFMAIN,12,3.66,45,https://www.digchip.com/datashe
 ANDREW,HDX8-59,HDX859,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HDX8-59 L,HDX859L,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HDX8-59 L MAIN,HDX859LMAIN,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,HDX8-59 L MAIN,HDX859LMAIN,8,2.44,41.5,https://www.datasheets360.com/pdf/-7751896179374140443
 ANDREW,HDX8-59L MAIN,HDX859LMAIN,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,HDX8-59 L MAIN,HDX859LMAIN,8,2.44,41.5,https://www.datasheets360.com/pdf/-7751896179374140443
 COMMSCOPE,HDX8-59 MAIN LF,HDX859MAINLF,8,2.44,41.5,https://www.datasheets360.com/pdf/-7751896179374140443
 COMMSCOPE,HDX8-59 MAIN RF,HDX859MAINRF,8,2.44,41.5,https://www.datasheets360.com/pdf/-7751896179374140443
 COMMSCOPE,HDX8-59MAIN RF,HDX859MAINRF,8,2.44,41.5,https://www.datasheets360.com/pdf/-7751896179374140443
@@ -269,6 +465,7 @@ ANDREW,HDX8-59 R MAIN,HDX859RMAIN,8,2.44,41.5,https://www.digchip.com/datasheets
 COMMSCOPE,HDX8-59 R MAIN,HDX859RMAIN,8,2.44,41.5,https://www.datasheets360.com/pdf/-7751896179374140443
 Radio Frequency Systems,HDX8-59R MAIN,HDX859RMAIN,8,2.44,41.5,https://www.datasheets360.com/pdf/-7751896179374140443
 COMMSCOPE,HDX8-59 R MAIN RF,HDX859RMAINRF,8,2.44,41.5,https://www.datasheets360.com/pdf/-7751896179374140443
+GABRIEL ELECTRONICS,HE4-107,HE4107,4,1.22,,11 GHz Antenna
 RADIO WAVES,HO6-59,HO659,6,1.83,39,Typo should be HP659. Using that gain.
 ANDREW,HP10 59,HP1059,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP10-59,HP1059,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -280,18 +477,18 @@ COMMSCOPE,HP10-59E,HP1059E,10,3.05,42.9,https://www.digchip.com/datasheets/parts
 ANDREW,HP10-59F,HP1059F,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP10-59F,HP1059F,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP10-59G,HP1059G,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,HP10-59G,HP1059G,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP-10-59G,HP1059G,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,HP10-59G,HP1059G,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP10-59-P1A,HP1059P1A,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP10-59W,HP1059W,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP10-59W,HP1059W,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP1059WB,HP1059WB,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,HP1059WB,HP1059WB,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP10-59WB,HP1059WB,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,HP1059WB,HP1059WB,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP10-59WB,HP1059WB,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP10-611E,HP10611E,10,3.05,43,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2F44d80f59%2Fandrew.com%2FHP8-186.pdf
-COMMSCOPE,HP10-611E,HP10611E,10,3.05,43,https://www.launch3telecom.com/commscopeandrew/hp10611p1a.html
 ANDREW,Hp10-611E,HP10611E,10,3.05,43,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2F44d80f59%2Fandrew.com%2FHP8-186.pdf
+COMMSCOPE,HP10-611E,HP10611E,10,3.05,43,https://www.launch3telecom.com/commscopeandrew/hp10611p1a.html
 ANDREW,HP10-65,HP1065,10,3.05,43.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HP10-65,HP1065,10,3.05,43.9,https://www.launch3telecom.com/commscopeandrew/hp1065.html
 ANDREW,HP10-65D,HP1065D,10,3.05,43.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
@@ -303,17 +500,18 @@ COMMSCOPE,HP10-65E,HP1065E,10,3.05,43.9,https://www.launch3telecom.com/commscope
 COMMSCOPE,hp10-65e,HP1065E,10,3.05,43.9,https://www.launch3telecom.com/commscopeandrew/hp1065.html
 ANDREW,HP10 65E P1A,HP1065EP1A,10,3.05,43.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,HP10-65E-P1A,HP1065EP1A,10,3.05,43.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,HP 10-65G,HP1065G,10,3.05,43.9,Comsearch's Frequency Coordination Database
 ANDREW,HP10-65G,HP1065G,10,3.05,43.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,HP 10-65G,HP1065G,10,3.05,43.9,Comsearch's Frequency Coordination Database
 COMMSCOPE,HP10-65G,HP1065G,10,3.05,43.9,https://www.launch3telecom.com/commscopeandrew/hp1065.html
 COMMSCOPE,HP10A-59,HP10A59,10,3.05,43.2,Comsearch's Frequency Coordination Database
+CommScope,HP12-57W,HP1257W,12,3.66,44.6,Comsearch's Frequency Coordination Database
 ANDREW,HP12-59,HP1259,12,3.66,45,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP12-59,HP1259,12,3.66,45,https://objects.eanixter.com/PD353926.PDF
 COMMSCOPE,HP12-59D,HP1259D,12,3.66,45,https://objects.eanixter.com/PD353926.PDF
 ANDREW,HP12-59E,HP1259E,12,3.66,45,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP12-59F,HP1259F,12,3.66,45,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,HP12-59F,HP1259F,12,3.66,45,https://objects.eanixter.com/PD353926.PDF
 ANDREW,hp12-59f,HP1259F,12,3.66,45,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,HP12-59F,HP1259F,12,3.66,45,https://objects.eanixter.com/PD353926.PDF
 COMMSCOPE,HP-12-59F,HP1259F,12,3.66,45,https://www.datasheets360.com/pdf/-7751896179374140443
 COMMSCOPE,HP12-59W,HP1259W,12,3.66,45,https://objects.eanixter.com/PD353926.PDF
 COMMSCOPE,HP12-59WB,HP1259WB,12,3.66,45,https://objects.eanixter.com/PD353926.PDF
@@ -321,13 +519,15 @@ ANDREW,HP12-65,HP1265,12,3.66,45.6,https://www.digchip.com/datasheets/parts/data
 Commscope,HP12-65D,HP1265D,12,3.66,45.6,https://objects.eanixter.com/PD353931.PDF
 ANDREW,HP12-65E,HP1265E,12,3.66,45.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HP12-65E,HP1265E,12,3.66,45.6,https://objects.eanixter.com/PD353931.PDF
-COMMSCOPE,HP1265G,HP1265G,12,3.66,45.6,https://objects.eanixter.com/PD353931.PDF
 ANDREW,HP12-65G,HP1265G,12,3.66,45.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,HP1265G,HP1265G,12,3.66,45.6,https://objects.eanixter.com/PD353931.PDF
 COMMSCOPE,HP12-65G,HP1265G,12,3.66,45.6,https://objects.eanixter.com/PD353931.PDF
 ANDREW,HP15-59D,HP1559D,15,4.57,46.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FHP15-59.pdf
 COMMSCOPE,HP15-59D,HP1559D,15,4.57,46.4,https://objects.eanixter.com/PD400300.PDF
+"RADIO WAVES, INC",HP3-59,HP359,3,0.91,33,Comsearch's Frequency Coordination Database
 RADIO WAVES,HP3-6,HP36,3,0.91,33.3,https://www.radiowaves.com/getmedia/70a14957-da0c-43d1-9642-f4def2654c20/HP3-6.aspx
 RADIO WAVES,HP3-6.4,HP364,3,0.91,33.4,https://www.radiowaves.com/en/product/hp3-6-4
+Commscope,HP4-107B,HP4107B,4,1.22,40.4,Comsearch's Frequency Coordination Database
 ANDREW,HP4-2201,HP42201,4,1.22,,Model does not belong in this band.
 ANDREW,HP4-220A,HP4220A,4,1.22,,Model does not belong in this band.
 RADIO WAVES,HP4-5.9,HP459,4,1.22,35,https://www.radiowaves.com/getmedia/b38e1116-15bd-44fb-abb0-d78f501eab49/HP4-5.9.aspx
@@ -338,12 +538,18 @@ COMMSCOPE,HP4-6,HP46,4,1.22,36.5,https://www.radiowaves.com/getmedia/422b3335-8b
 RADIO WAVES,HP4-6,HP46,4,1.22,36.5,https://www.radiowaves.com/getmedia/422b3335-8b4c-4b58-bed7-a7f94772045e/HP4-6.aspx
 RADIO WAVES,HP4-6.4,HP464,4,1.22,35.9,https://www.radiowaves.com/en/product/hp4-6-4
 RADIO WAVES,HP4-64,HP464,4,1.22,35.9,https://www.radiowaves.com/getmedia/adaab50d-559f-4684-8e3d-5a75816185d8/HP4-6.4.aspx
+Radio Waves,HP4-6/4.0 ft,HP4640FT,4,1.22,36.5,Assumed to be HP4-6
 COMMSCOPE,HP4-65B,HP465B,4,1.22,36,https://objects.eanixter.com/PD354008.PDF
 COMMSCOPE,HP4-65C,HP465C,4,1.22,36,https://objects.eanixter.com/PD354008.PDF
+Commscope,HP5-59WC,HP559WC,,,,Diameter indeterminate
+Andrew Corporation,HP-59J,HP59J,,,,Indeterminate. 
+ANdrews,HP-59K,HP59K,,,,Indeterminate. 
+MARK ANTENNA,HP-60120W,HP60120W,10,3.05,43.4,Comsearch's Frequency Coordination Database
 Mark Antenna,HP-60144W,HP60144W,12,3.66,45.1,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna Products,HP-60A120D LF,HP60A120DLF,10,3.05,43.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antennas,HP-60A120L,HP60A120L,10,3.05,43.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-Mark Antenna,HP-60A120L LF,HP60A120LLF,10,3.05,43.2,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+Mark Antennas,HP-60A120  LF,HP60A120LF,10,3.05,43.4,Based on HP60A120L
+Mark Antenna,HP-60A120L LF,HP60A120LLF,10,3.05,43.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,HP-60A144D LF,HP60A144DLF,12,3.66,45,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,HP-60A72,HP60A72,6,1.83,38.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna,HP-60A72 LF,HP60A72LF,6,1.83,38.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
@@ -352,21 +558,22 @@ MARK ANTENNA PRODUCTS,HP-60A96,HP60A96,8,2.44,41.6,https://www.datasheetarchive.
 MARK ANTENNAS,HP-60A96D,HP60A96D,8,2.44,41.6,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,HP-60A96D RF,HP60A96DRF,8,2.44,41.6,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNAS,HP-60A96D* RF,HP60A96DRF,8,2.44,41.6,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNA PROD,HP-60A96 (LF),HP60A96LF,8,2.44,41.6,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK,HP-60A96 LF,HP60A96LF,8,2.44,41.6,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA PROD,HP-60A96 (LF),HP60A96LF,8,2.44,41.6,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,HP-60A96 RF,HP60A96RF,8,2.44,41.6,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 ANDREW,HP6-107G,HP6107G,,,,Model does not belong in this band.
-Commscope/Andrew,HP657W,HP657W,6,1.83,38.5,https://objects.eanixter.com/PD354043.PDF
 ANDREW,HP6-57W,HP657W,6,1.83,38.5,Comsearch's Frequency Coordination Database
 COMMSCOPE,HP6-57W,HP657W,6,1.83,38.5,https://objects.eanixter.com/PD354043.PDF
+Commscope/Andrew,HP657W,HP657W,6,1.83,38.5,https://objects.eanixter.com/PD354043.PDF
 COMMSCOPE,HP6-57WA,HP657WA,6,1.83,38.5,https://objects.eanixter.com/PD354043.PDF
-RADIO WAVES,HP6-5.9,HP659,6,1.83,39,https://www.radiowaves.com/getmedia/fbd5837d-c14d-41ce-8225-bb25edab4af3/HP6-5.9.aspx
-"RADIO WAVES, INC",HP659,HP659,6,1.83,39,https://www.radiowaves.com/getmedia/fbd5837d-c14d-41ce-8225-bb25edab4af3/HP6-5.9.aspx
 ANDREW,HP6-59,HP659,6,1.83,39,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php Using Radio Waves gain because it's higher for this standardModel
 COMMSCOPE,HP6-59,HP659,6,1.83,39,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php Using Radio Waves gain because it's higher for this standardModel
+RADIO WAVES,HP6-5.9,HP659,6,1.83,39,https://www.radiowaves.com/getmedia/fbd5837d-c14d-41ce-8225-bb25edab4af3/HP6-5.9.aspx
 RADIO WAVES,HP6-59,HP659,6,1.83,39,https://www.radiowaves.com/getmedia/fbd5837d-c14d-41ce-8225-bb25edab4af3/HP6-5.9.aspx
-RFS,HP6-59,HP659,6,1.83,39,https://www.radiowaves.com/getmedia/fbd5837d-c14d-41ce-8225-bb25edab4af3/HP6-5.9.aspx
 RADIO WAVES,Hp6-59,HP659,6,1.83,39,https://www.radiowaves.com/getmedia/fbd5837d-c14d-41ce-8225-bb25edab4af3/HP6-5.9.aspx
+"RADIO WAVES, INC",HP659,HP659,6,1.83,39,https://www.radiowaves.com/getmedia/fbd5837d-c14d-41ce-8225-bb25edab4af3/HP6-5.9.aspx
+RFS,HP6-59,HP659,6,1.83,39,https://www.radiowaves.com/getmedia/fbd5837d-c14d-41ce-8225-bb25edab4af3/HP6-5.9.aspx
+MARK ANTENNA,HP-6596WD,HP6596WD,8,2.44,42.2,Comsearch's Frequency Coordination Database
 COMMSCOPE,HP6-59B,HP659B,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP6-59D,HP659D,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP6-59E,HP659E,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -381,12 +588,12 @@ COMMSCOPE,HP6-59H,HP659H,6,1.83,38.6,https://www.digchip.com/datasheets/parts/da
 ANDREW CORP,HP6-59H RF,HP659HRF,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP6 59J,HP659J,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,HP6-59J,HP659J,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,HP6-59J,HP659J,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,hp6-59j,HP659J,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,HP6-59J,HP659J,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP6-59K,HP659K,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,HP6--59K,HP659K,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP6-59K,HP659K,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP6-59k,HP659K,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW,HP6--59K,HP659K,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP6-59 P1A,HP659P1A,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP6-59-P1A,HP659P1A,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP6-59-P3A/K,HP659P3AK,6,1.83,38.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -399,7 +606,15 @@ ANDREW,HP6-59WB,HP659WB,6,1.83,39,https://www.digchip.com/datasheets/parts/datas
 COMMSCOPE,HP6-59WB,HP659WB,6,1.83,39,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP6-59WC,HP659WC,6,1.83,39,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP6-59WC,HP659WC,6,1.83,39,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+MARK ANTENNA,HP-65A120,HP65A120,10,3.05,44,Comsearch's Frequency Coordination Database
+MARK ANTENNA,HP-65A120D,HP65A120D,10,3.05,44,Comsearch's Frequency Coordination Database
+MARK ANTENNA,HP-65A120 LF,HP65A120LF,10,3.05,44,Comsearch's Frequency Coordination Database
+MARK ANTENNA,HP-65A72 LF,HP65A72LF,6,1.83,39.9,Comsearch's Frequency Coordination Database
+MARK ANTENNA,HP-65A72 RF,HP65A72RF,6,1.83,39.9,Comsearch's Frequency Coordination Database
+MARK ANTENNA,HP-65A96D RF,HP65A96DRF,8,2.44,42.4,Comsearch's Frequency Coordination Database
+MARK ANTENNA,HP-65A96 LF,HP65A96LF,8,2.44,42.4,Comsearch's Frequency Coordination Database
 Mark Antenna,HP-65A96 RF,HP65A96RF,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+Andrew Corporation,HP^-65E,HP65E,,,,Indeterminate. 
 RADIO WAVES,HP6-6,HP66,6,1.83,39.3,https://www.radiowaves.com/getmedia/ede15878-f905-48f9-b209-87ad2a770b9e/HP6-6.aspx
 RADIO WAVES,hp6-6,HP66,6,1.83,39.3,https://www.radiowaves.com/getmedia/ede15878-f905-48f9-b209-87ad2a770b9e/HP6-6.aspx
 RADIO WAVES,HP6-64,HP664,6,1.83,39.1,https://www.radiowaves.com/getmedia/54bd53db-9fc3-47dc-a6f9-cd44b76c670c/HP6-6.4.aspx
@@ -415,24 +630,27 @@ ANDREW,HP6-65F,HP665F,6,1.83,39.8,https://www.digchip.com/datasheets/parts/datas
 COMMSCOPE,HP6-65F,HP665F,6,1.83,39.8,https://objects.eanixter.com/PD354057.PDF
 ANDREW,HP6-65H,HP665H,6,1.83,39.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HP6-65H,HP665H,6,1.83,39.8,https://objects.eanixter.com/PD354057.PDF
+ANDREW,HP6-65J,HP665J,6,1.83,39.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+ANDREW,hp6-65j,HP665J,6,1.83,39.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HP6 65J,HP665J,6,1.83,39.8,https://objects.eanixter.com/PD354057.PDF
 COMMSCOPE,HP6?65J,HP665J,6,1.83,39.8,https://objects.eanixter.com/PD354057.PDF
-ANDREW,HP6-65J,HP665J,6,1.83,39.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HP6-65J,HP665J,6,1.83,39.8,https://objects.eanixter.com/PD354057.PDF
-ANDREW,hp6-65j,HP665J,6,1.83,39.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,Hp6-65J,HP665J,6,1.83,39.8,https://objects.eanixter.com/PD354057.PDF
 ANDREW,HP6-65K,HP665K,6,1.83,39.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HP6-65K,HP665K,6,1.83,39.8,https://objects.eanixter.com/PD354057.PDF
 COMMSCOPE,HP6-65L,HP665L,6,1.83,39.8,https://objects.eanixter.com/PD354057.PDF
 RADIO WAVES,HP6-69,HP669,6,1.83,39.8,Typo should be HP665. Using that gain. 
 RADIO WAVES,HP6-6EX,HP66EX,6,1.83,39.8,Typo should be HP665E. Using that gain. 
-ANDREW,HP8-186,HP8186,8,2.44,30.7,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2F44d80f59%2Fandrew.com%2FHP8-186.pdf
+Radio Waves Inc,HP6D-59,HP6D59,6,1.83,38.7,Assumed to be HPD6-59
+Commscope,HP8,HP8,8,2.44,,8 foot antenna. Various bands  have gain ranges of 41.2 - 42.3
+ANDREW,HP8-186,HP8186,8,2.44,41.9,Comsearch's Frequency Coordination Database
+CommScope,HP8-186 2 GHZ (V),HP81862GHZV,8,2.44,41.9,Comsearch's Frequency Coordination Database
 ANDREW,HP8-50F,HP850F,8,2.44,,Indeterminate.  Band designator 50 could be several different options.
 COMMSCOPE,HP8-56F,HP856F,8,2.44,,Indeterminate.  Band designator 56 could be several different options.
-Commscope/Andrew,HP857W,HP857W,8,2.44,41.2,https://www.launch3telecom.com/commscopeandrew/hp857w.html
 ANDREW,HP8-57W,HP857W,8,2.44,41.2,https://objects.eanixter.com/PD354132.PDF
-COMMSCOPE,HP8-57W,HP857W,8,2.44,41.2,https://www.launch3telecom.com/commscopeandrew/hp857w.html
 ANDREW,HP8-57-W,HP857W,8,2.44,41.2,https://objects.eanixter.com/PD354132.PDF
+COMMSCOPE,HP8-57W,HP857W,8,2.44,41.2,https://www.launch3telecom.com/commscopeandrew/hp857w.html
+Commscope/Andrew,HP857W,HP857W,8,2.44,41.2,https://www.launch3telecom.com/commscopeandrew/hp857w.html
 <KRA26>,<HP8-59>,HP859,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP8-59,HP859,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP8-59,HP859,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -442,9 +660,9 @@ COMMSCOPE,HP8-59D,HP859D,8,2.44,41.5,https://www.digchip.com/datasheets/parts/da
 ANDREW,HP8-59E,HP859E,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP8-59E,HP859E,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP8-59F,HP859F,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,HP8-59F,HP859F,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,Hp8-59F,HP859F,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP8-59f,HP859F,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,HP8-59F,HP859F,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP8-59J,HP859J,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HP8-59J,HP859J,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HP8-59-P3A,HP859P3A,8,2.44,41.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -469,21 +687,29 @@ ANDREW,HP8-65E,HP865E,8,2.44,42.3,https://www.digchip.com/datasheets/parts/datas
 COMMSCOPE,HP8-65E,HP865E,8,2.44,42.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,hp8-65e,HP865E,8,2.44,42.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,HP8 65E MAIN & HP6 65F DI,HP865EMAINHP665FDI,8,2.44,42.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,HP865F,HP865F,8,2.44,42.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,HP8-65F,HP865F,8,2.44,42.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,HP865F,HP865F,8,2.44,42.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HP8-65F,HP865F,8,2.44,42.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,HP8-65-P1A,HP865P1A,8,2.44,42.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HP8-65-P3M,HP865P3M,8,2.44,42.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+"Radio Waves, Inc.",HPD306,HPD306,3,0.91,33.1,https://www.radiowaves.com/en/product/hpd3-6
+"RADIO WAVES, INC",HPD3-59,HPD359,3,0.91,32.8,Comsearch's Frequency Coordination Database
 RADIO WAVES,HPD3-6,HPD36,3,0.91,33.1,https://www.radiowaves.com/en/product/hpd3-6
+"Radio Waves, Inc.",HPD4-50,HPD450,4,1.22,35.7,Typo of HPD4-59
 RADIO WAVES,HPD4-59,HPD459,4,1.22,35.7,https://www.radiowaves.com/en/product/hpd4-5-9
 RADIO WAVES,HPD4-6,HPD46,4,1.22,36.3,https://www.radiowaves.com/getmedia/1e60f342-4fd0-434d-bbd6-26c332d98cd0/HPD4-6.aspx
 RADIO WAVES,HPD4-64,HPD464,4,1.22,35.7,https://www.radiowaves.com/getmedia/35b3f4df-dab5-46d2-9e8d-8c4c1fbdb1a3/HPD4-6.4.aspx
+Radiowaves,HPD4-rs,HPD4RS,4,1.22,,Band indeterminate. 
+"Radio Waves, Inc.",HPD5-59,HPD559,,,,Diameter indeterminate
 RADIO WAVES,HPD6-59,HPD659,6,1.83,38.7,https://www.radiowaves.com/en/product/hpd6-5-9
 RADIO WAVES,HPD6-6,HPD66,6,1.83,39.1,https://www.radiowaves.com/getmedia/3491e115-f6ca-4a33-bdb9-6077b7f797dd/HPD6-6.aspx
 RADIO WAVES,HPD6-64,HPD664,6,1.83,38.9,https://www.radiowaves.com/getmedia/4047a681-60b2-4efb-97bc-9f27691d263f/HPD6-6.4.aspx
+"Radio Waves, Inc.",HPD6-69,HPD669,6,1.83,,theres a hpd6-59…
 RADIO WAVES,HPD8-59,HPD859,8,2.44,41.4,Comsearch's Frequency Coordination Database
 RADIO WAVES,HPD8-59F,HPD859F,8,2.44,41.4,Comsearch's Frequency Coordination Database
 RADIO WAVES,HPD8-6,HPD86,8,2.44,41.9,Comsearch's Frequency Coordination Database
+"RADIO WAVES, INC",HPD9-59,HPD959,,,,Diameter indeterminate
+GABRIEL ELECTRONICS,HPHB-6A,HPHB6A,,,,Indeterminate. 
 ANDREW,HPS12-59D,HPS1259D,12,3.66,44.8,Typo should be HPX1259D. Using that gain.
 ANDREW,HPX10-59,HPX1059,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HPX10-59,HPX1059,10,3.05,43.1,https://objects.eanixter.com/PD354271.PDF
@@ -515,11 +741,12 @@ ANDREW,HPX6-59K,HPX659K,6,1.83,38.8,https://www.digchip.com/datasheets/parts/dat
 COMMSCOPE,HPX6-59K,HPX659K,6,1.83,38.8,https://www.datasheets360.com/pdf/8090544319402768422
 ANDREW,HPX6-59-P3A/K,HPX659P3AK,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HPX6-59-P3A/K,HPX659P3AK,6,1.83,38.8,https://www.datasheets360.com/pdf/8090544319402768422
+ANDREW CORP.,HPX-65D,HPX65D,,,,Diameter indeterminate
 COMMSCOPE,HPX6-65D,HPX665D,6,1.83,39.5,https://www.datasheets360.com/pdf/5940162334482066781
 ANDREW,HPX6-65E,HPX665E,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HPX6-65E,HPX665E,6,1.83,39.5,https://www.datasheets360.com/pdf/5940162334482066781
-COMMSCOPE,HPX6 65F,HPX665F,6,1.83,39.5,https://www.datasheets360.com/pdf/5940162334482066781
 ANDREW,HPX6-65F,HPX665F,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,HPX6 65F,HPX665F,6,1.83,39.5,https://www.datasheets360.com/pdf/5940162334482066781
 COMMSCOPE,HPX6-65F,HPX665F,6,1.83,39.5,https://www.datasheets360.com/pdf/5940162334482066781
 ANDREW,HPX8-59,HPX859,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HPX8-59,HPX859,8,2.44,41.3,https://www.datasheets360.com/pdf/8090544319402768422
@@ -528,22 +755,25 @@ ANDREW,HPX8-59D,HPX859D,8,2.44,41.3,https://www.digchip.com/datasheets/parts/dat
 COMMSCOPE,HPX8-59D,HPX859D,8,2.44,41.3,https://www.datasheets360.com/pdf/8090544319402768422
 ANDREW,HPX8 59E,HPX859E,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HPX8?59E,HPX859E,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,HPX8-59E,HPX859E,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HPX8?59E,HPX859E,8,2.44,41.3,https://www.datasheets360.com/pdf/8090544319402768422
 COMMSCOPE,HPX859E,HPX859E,8,2.44,41.3,https://www.datasheets360.com/pdf/8090544319402768422
-ANDREW,HPX8-59E,HPX859E,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HPX8-59E,HPX859E,8,2.44,41.3,https://www.datasheets360.com/pdf/8090544319402768422
+Andrew Corporation,HPX8-59-P1A,HPX859P1A,8,2.44,41.3,Assumed to be HPX8-59
 COMMSCOPE,HPX8-65,HPX865,8,2.44,42,https://www.datasheets360.com/pdf/5940162334482066781
 ANDREW,HPX8-65D,HPX865D,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HPX8-65D,HPX865D,8,2.44,42,https://www.datasheets360.com/pdf/5940162334482066781
 ANDREW,HPX8A-59,HPX8A59,8,2.44,41,Comsearch's Frequency Coordination Database
 COMMSCOPE,HPX8A-59,HPX8A59,8,2.44,41,Comsearch's Frequency Coordination Database
+RFS Cablewave,HRS-CX-06G08D1,HRSCX06G08D1,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",HRS-CX-06G28D1-H,HRSCX06G28D1H,,,,Radio - Indeterminate. 
 COMMSCOPE,HS6-6W,HS66W,6,1.83,39.1,Typo should be HX66W. Using that gain
 ANDREW,HSX10-59A LF,HSX1059ALF,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,HSX10-59A LF,HSX1059ALF,10,3.05,42.9,https://www.datasheets360.com/pdf/8090544319402768422
 ANDREW,HSX10-59A (RF),HSX1059ARF,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HSX10-59A RF,HSX1059ARF,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,HSX10-59A RF,HSX1059ARF,10,3.05,42.9,https://www.datasheets360.com/pdf/8090544319402768422
 ANDREW,HSX10-59A-RF,HSX1059ARF,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,HSX10-59A RF,HSX1059ARF,10,3.05,42.9,https://www.datasheets360.com/pdf/8090544319402768422
 ANDREW,HSX10-59-P3A LF,HSX1059P3ALF,10,3.05,42.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,HSX10-64A RF,HSX1064ARF,10,3.05,43.6,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FHSX8-64A.pdf
 ANDREW,HSX12-59A,HSX1259A,12,3.66,44.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -567,8 +797,8 @@ ANDREW,HSX6-59-P3A LF,HSX659P3ALF,6,1.83,38.8,https://www.digchip.com/datasheets
 ANDREW,HSX6-64A LF,HSX664ALF,6,1.83,39.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,HSX6-64A LF,HSX664ALF,6,1.83,39.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,HSX6-64A R,HSX664AR,6,1.83,39.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,HSX664A RF,HSX664ARF,6,1.83,39.6,https://www.datasheets360.com/pdf/5940162334482066781
 ANDREW,HSX6-64A RF,HSX664ARF,6,1.83,39.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,HSX664A RF,HSX664ARF,6,1.83,39.6,https://www.datasheets360.com/pdf/5940162334482066781
 COMMSCOPE,HSX6-64A RF,HSX664ARF,6,1.83,39.6,https://www.datasheets360.com/pdf/5940162334482066781
 COMMSCOPE,HSX6-64B LF,HSX664BLF,6,1.83,39.6,https://www.datasheets360.com/pdf/5940162334482066781
 ANDREW,HSX6-64B RF,HSX664BRF,6,1.83,39.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
@@ -587,23 +817,101 @@ ANDREW,HSX8-64A RF,HSX864ARF,8,2.44,42,https://www.digchip.com/datasheets/parts/
 ANDREW,HSX8-64B RF,HSX864BRF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,HSX8-64-RF,HSX864RF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,HX10-6W,HX106W,10,3.05,43.2,https://www.commscope.com/globalassets/digizuite/262649-p360-hx10-6w-6gf-external.pdf
+Commscope,HX12-6W,HX126W,12,3.66,45,Comsearch's Frequency Coordination Database
+Commscope,HX5-5W,HX55W,,,,Indeterminate
+CommScope,HX6-611B,HX6611B,6,1.83,39.3,Comsearch's Frequency Coordination Database
 ANDREW,HX6-6W,HX66W,6,1.83,39.1,https://www.commscope.com/globalassets/digizuite/260874-p360-hx6-6w-external.pdf
 COMMSCOPE,HX6-6W,HX66W,6,1.83,39.1,https://www.commscope.com/globalassets/digizuite/260874-p360-hx6-6w-external.pdf
 COMMSCOPE,HX6-6W-6GR,HX66W6GR,6,1.83,39.1,https://www.commscope.com/globalassets/digizuite/262695-p360-hx6-6w-6gr-external.pdf
+Commscope,HX8-6Q,HX86Q,8,2.44,41.6,"Probably meant to be -6W, Q is right next to W"
 ANDREW,HX8-6W,HX86W,8,2.44,41.6,https://www.commscope.com/globalassets/digizuite/260884-p360-hx8-6w-external.pdf
 COMMSCOPE,HX8-6W,HX86W,8,2.44,41.6,https://www.commscope.com/globalassets/digizuite/260884-p360-hx8-6w-external.pdf
+Aviat Networks,I600V3HL6 30M 256Q 179M,I600V3HL630M256Q179M,,,,Radio - Indeterminate. 
+Aviat Networks,I600V3HL6-30M-256Q-179MB,I600V3HL630M256Q179MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I600V3HL6-30M-256Q-179MB,I600V3HL630M256Q179MB,,,,Radio - Indeterminate. 
+Aviat Networks,I600V3HU6-30M 256Q 179MB,I600V3HU630M256Q179MB,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,I64EU630M179OC3,I64EU630M179OC3,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,I64EU630M200R70 ACM,I64EU630M200R70ACM,,,,Radio - Indeterminate. 
+Aviat Networks,I64EU630MACMR70 ACM,I64EU630MACMR70ACM,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,I64HL660M344R70,I64HL660M344R70,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,I64HL660M534R70 ACM,I64HL660M534R70ACM,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,I64HU610M051R70 ACM,I64HU610M051R70ACM,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,I64HU630M179OC3,I64HU630M179OC3,,,,Radio - Indeterminate. 
+Aviat Networks,I64HU630M267R70ACM,I64HU630M267R70ACM,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,I64SL630M227R70 ACM,I64SL630M227R70ACM,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,I64SL660M344R70,I64SL660M344R70,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,I64SL660M534R70 ACM,I64SL660M534R70ACM,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M,I6V4EHL630M,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M 1024Q 227MB,I6V4EHL630M1024Q227MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M 128Q 155MB R,I6V4EHL630M128Q155MBR,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M 16Q 90MB R70,I6V4EHL630M16Q90MBR70,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M 2048Q 245MB,I6V4EHL630M2048Q245MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M 256Q 180MB R,I6V4EHL630M256Q180MBR,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M 32Q 109MB R7,I6V4EHL630M32Q109MBR7,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M 4096Q 267MB,I6V4EHL630M4096Q267MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M 512Q 200MB R,I6V4EHL630M512Q200MBR,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M 64Q 132MB R7,I6V4EHL630M64Q132MBR7,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4EHL6-30M QPSK 39MB R7,I6V4EHL630MQPSK39MBR7,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4HL6-30M 1024Q 227MB R,I6V4HL630M1024Q227MBR,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4HL6-30M 128Q 155MB R7,I6V4HL630M128Q155MBR7,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4HL6-30M 2048Q 245MB R,I6V4HL630M2048Q245MBR,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4HL6-30M 256Q 180MB R7,I6V4HL630M256Q180MBR7,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4HL6-30M 4096Q 267MB R,I6V4HL630M4096Q267MBR,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4HL6-30M 512Q 200MB R7,I6V4HL630M512Q200MBR7,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4HL6-30M 64Q 132MB R70,I6V4HL630M64Q132MBR70,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4SL6-30M 1024Q 227MB R,I6V4SL630M1024Q227MBR,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4SL6-30M 128Q 155MB R7,I6V4SL630M128Q155MBR7,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4SL6-30M 16Q 90MB R70,I6V4SL630M16Q90MBR70,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4SL6-30M 2048Q 245MB R,I6V4SL630M2048Q245MBR,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4SL6-30M 256Q 180MB R7,I6V4SL630M256Q180MBR7,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4SL6-30M 32Q 109MB R70,I6V4SL630M32Q109MBR70,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4SL6-30M 4096Q 267MB R,I6V4SL630M4096Q267MBR,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4SL6-30M 512Q 200MB R7,I6V4SL630M512Q200MBR7,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4SL6-30M 64Q 132MB R70,I6V4SL630M64Q132MBR70,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6V4SL6-30M QPSK 39MB R70,I6V4SL630MQPSK39MBR70,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,I6V4SU6_5M 128Q 22MbR70,I6V4SU65M128Q22MBR70,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6VEHL6-30M,I6VEHL630M,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",I6VHL6-30M,I6VHL630M,,,,Radio - Indeterminate. 
+SAF Tehnika,IntG6L_148M_30S ACM,INTG6L148M30SACM,,,,Radio - Indeterminate. 
+CERAGON NETWORKS,IP20D-HP6-30X-Z ACM,IP20DHP630XZACM,,,,Radio - Indeterminate. 
+VISLINK,IPL059THAAH,IPL059THAAH,,,,Indeterminate. 
+ALCATEL NETWORK SYSTEMS,JF6-8803 MDR-4106C,JF68803MDR4106C,,,,Radio - Indeterminate. 
+Alcatel Network Syst,JF6-9402 MDR 6506-4,JF69402MDR65064,,,,Radio - Indeterminate. 
+ALCATEL NETWORK SYSTEMS,JF6-9402 MDR-6506-4,JF69402MDR65064,,,,Radio - Indeterminate. 
 WESTERN ELECTRIC,KS15676,KS15676,10,3.05,43.2,https://www.telecomarchive.com/docs/bsp-archive/402/402-421-100_I2.pdf
 WESTERN ELECTRIC,KS15676 BC,KS15676BC,10,3.05,43.2,https://www.telecomarchive.com/docs/bsp-archive/402/402-421-100_I2.pdf
 WESTERN ELECTRIC,KS15676 BD,KS15676BD,10,3.05,43.2,https://www.telecomarchive.com/docs/bsp-archive/402/402-421-100_I2.pdf
 WESTERN ELECTRIC,"KS15676, BD",KS15676BD,10,3.05,43.2,https://www.telecomarchive.com/docs/bsp-archive/402/402-421-100_I2.pdf
 WESTERN ELECTRIC,"KS15676,BD",KS15676BD,10,3.05,43.2,https://www.telecomarchive.com/docs/bsp-archive/402/402-421-100_I2.pdf
 WESTERN ELECTRIC,KS15676BD,KS15676BD,10,3.05,43.2,https://www.telecomarchive.com/docs/bsp-archive/402/402-421-100_I2.pdf
+Western Electric,KS1676 BC,KS1676BC,10,3.05,43.2,Assumed to be KS15676BC
 WESTERN ELECTRIC,KS-21972,KS21972,10,3.05,43.5,http://etler.com/docs/bsp-archive/402/402-422-100_I1.pdf
+GABRIEL ELECTRONICS,L10P456,L10P456,10,3.05,44,Comsearch's Frequency Coordination Database
+AINSLIE,L-6510W,L6510W,,,,Indeterminate. 
+Cambium Networks,L6820C-V2,L6820CV2,,,,Radio - Indeterminate. 
+GABRIEL ELECTRONICS,L8DP456,L8DP456,8,2.44,42,Comsearch's Frequency Coordination Database
+Andrew Corporation,LBW-6G-8DS1,LBW6G8DS1,,,,Radio - Indeterminate. 
+Andrew Corporation,LP6-65D,LP665D,6,1.83,39.9,Typo should be PL6-65D
+Commscope,LX6-6W,LX66W,6,1.83,38.1,Comsearch's Frequency Coordination Database
+CommScope,LX6-6W / 5.9 ft,LX66W59FT,6,1.83,38.1,Comsearch's Frequency Coordination Database
 COMMSCOPE,LX6-6W (CAT A),LX66WCATA,6,1.83,38.1,https://www.commscope.com/globalassets/digizuite/277061-p360-lx6-6w-6gr-external.pdf
+"Aviat Networks, Inc.",M06K77-21,M06K7721,,,,Indeterminate. 
+MARK ANTENNA,M54009,M54009,8,2.44,42.4,Antenna Code for P-65A96 RF
+Mark Antenna,M61002,M61002,10,3.05,44,Comsearch's Frequency Coordination Database
+Mark Antenna,M64210,M64210,8,2.44,42.2,Antenna Code for HP-6596WD
+Mark Antenna,M65000,M65000,10,3.05,43.9,Comsearch's Frequency Coordination Database
+Mark Antenna,M65001,M65001,10,3.05,44,Antenna Code for MHP-65A120 RF
+Mark Antenna,M65301,M65301,10,3.05,44,Comsearch's Frequency Coordination Database
+Mark Antennas,M84600,M84600,6,1.83,39.9,Antenna Code for P-6572
+"Alcatel-Lucent USA, Inc.",MDR-8706-16,MDR870616,,,,Radio - Indeterminate. 
+"ALCATEL-LUCENT USA, INC",MDR-8706E-150,MDR8706E150,,,,Radio - Indeterminate. 
+ALCATEL-LUCENT,MDR-8706E-50,MDR8706E50,,,,Radio - Indeterminate. 
+ALCATEL-LUCENT,MDR-870E-150,MDR870E150,,,,Radio - Indeterminate. 
 MARK ANTENA PRODUCTS,MHP-60120W,MHP60120W,10,3.05,43.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,MHP-60120WD LF,MHP60120WDLF,10,3.05,43.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNA,MHP-60A 120D,MHP60A120D,10,3.05,43.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA,MHP-6072WD,MHP6072WD,6,1.83,38.8,Comsearch's Frequency Coordination Database
 Mark,MHP-60A120D,MHP60A120D,10,3.05,43.4,Comsearch's Frequency Coordination Database
+MARK ANTENNA,MHP-60A 120D,MHP60A120D,10,3.05,43.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark,MHP-60A120D (LF),MHP60A120DLF,10,3.05,43.4,Comsearch's Frequency Coordination Database
 MARK ANTENNA,MHP60A120D LF,MHP60A120DLF,10,3.05,43.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna,MHP-60A120D LF,MHP60A120DLF,10,3.05,43.4,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
@@ -624,25 +932,70 @@ Mark Antenna Prod,MHP-60A72D (RF),MHP60A72DRF,6,1.83,38.8,https://www.datasheeta
 Mark Antennas,MHP-60A72D RF,MHP60A72DRF,6,1.83,38.8,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna,MHP-60A72 LF,MHP60A72LF,6,1.83,38.8,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA PROD,MHP-60A72 RF,MHP60A72RF,6,1.83,38.8,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA,MHP-60A96,MHP60A96,8,2.44,41.3,Comsearch's Frequency Coordination Database
 MARK ANTENNA PROD,MHP-60A96D,MHP60A96D,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,MHP-60A96D (LF),MHP60A96DLF,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna,MHP-60A96D LF,MHP60A96DLF,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNA PROD,MHP-60A96D (RF),MHP60A96DRF,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,MHP-60A96D RF,MHP60A96DRF,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA PROD,MHP-60A96D (RF),MHP60A96DRF,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+Mark Antenna,MHP-60A96 LF,MHP60A96LF,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=0480ca47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=MHP-60A72DL
 MARK ANTENNA PRODUCTS,MHP60A96 LF,MHP60A96LF,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 ,MHP-60A96 LF,MHP60A96LF,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=0480ca47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=MHP-60A72DL
-Mark Antenna,MHP-60A96 LF,MHP60A96LF,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=0480ca47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=MHP-60A72DL
 MARK ANTENNA PROD,MHP-60A96 RF,MHP60A96RF,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna Products,MHP-60WA96,MHP60WA96,8,2.44,41.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+Mark Antennas,MHP-65A120D LF,MHP65A120DLF,10,3.05,44,Comsearch's Frequency Coordination Database
+MARK ANTENNA,MHP-65A120D RF,MHP65A120DRF,10,3.05,44,Comsearch's Frequency Coordination Database
+MARK ANTENNA,MHP-65A120 LF,MHP65A120LF,10,3.05,44,Comsearch's Frequency Coordination Database
+MARK ANTENNA,MHP-65A120 RF,MHP65A120RF,10,3.05,44,Comsearch's Frequency Coordination Database
+MARK ANTENNA,MHP-65A120W LF,MHP65A120WLF,10,3.05,44,Comsearch's Frequency Coordination Database
+MARK ANTENNA,MHP-65A120W RF,MHP65A120WRF,10,3.05,44,Comsearch's Frequency Coordination Database
+MARK ANTENNA PROD,MHP-65A72D RF,MHP65A72DRF,6,1.83,39.7,Comsearch's Frequency Coordination Database
 Mark RSI,MHP-65A96DL,MHP65A96DL,8,2.44,42.4,Comsearch's Frequency Coordination Database
+MARK ANTENNA,MHP-65A96D LF,MHP65A96DLF,8,2.44,42.4,Comsearch's Frequency Coordination Database
+MARK ANTENNA,MHP-65A96D RF,MHP65A96DRF,8,2.44,42.4,Comsearch's Frequency Coordination Database
+MARK ANTENNA,MHP-65A96 RF,MHP65A96RF,8,2.44,42.4,Comsearch's Frequency Coordination Database
+ERICSSON,Mini Link 6600 MMU1002,MINILINK6600MMU1002,,,,Radio - Indeterminate. 
+ERICSSON,Mini Link 6600 Split,MINILINK6600SPLIT,,,,Radio - Indeterminate. 
+ERICSSON,ML6206UAAC/030/01kM/F8B A,ML6206UAAC03001KMF8BA,,,,Radio - Indeterminate. 
+Ericsson,ML6206UAAC-060-B8B,ML6206UAAC060B8B,,,,Radio - Indeterminate. 
+ERICSSON,ML6600/6363/6LSA/367/060/,ML660063636LSA367060,,,,Radio - Indeterminate. 
+ERICSSON,ML6600/6365/06SA/1367/060,ML6600636506SA1367060,,,,Radio - Indeterminate. 
+ERICSSON,ML6600/6365/06SA/367/060,ML6600636506SA367060,,,,Radio - Indeterminate. 
+ERICSSON,ML6600/6365CA/06SA/364/03,ML66006365CA06SA36403,,,,Radio - Indeterminate. 
+MICROWAVE NETWORKS,MNIH6-6,MNIH66,6,1.83,39.3,Comsearch's Frequency Coordination Database
+Andrew Corporation,Model: P8-65D,MODELP865D,8,2.44,42.3,Comsearch's Frequency Coordination Database
+Nokia,MPT-HLC Plus,MPTHLCPLUS,,,,Radio - Indeterminate. 
+Nokia,MTP-HLC Plus,MTPHLCPLUS,,,,Radio - Indeterminate. 
+Prose,MW-V12D6W,MWV12D6W,4,1.22,35,Comsearch's Frequency Coordination Database
+MICROWAVE NETWORKS INC,MX/I/6G/10M/HP 64Q 45M AM,MXI6G10MHP64Q45MAM,,,,Radio - Indeterminate. 
+MICROWAVE NETWORKS INC,MX-I-6G-30M-HP,MXI6G30MHP,,,,Radio - Indeterminate. 
+MICROWAVE NETWORKS INC,MX-I-6G-30M-MH,MXI6G30MMH,,,,Radio - Indeterminate. 
+MICROWAVE NETWORKS INC,MX+I-6G-60M-HP,MXI6G60MHP,,,,Radio - Indeterminate. 
+MICROWAVE NETWORKS INC,MX+/I/6LG/30M/UHP 512QAM,MXI6LG30MUHP512QAM,,,,Radio - Indeterminate. 
+MICROWAVE NETWORKS INC,MX+/I/U6G/30M/HP 512QAM A,MXIU6G30MHP512QAMA,,,,Radio - Indeterminate. 
+"Cambium Networks, LTD",N060080L001A RF,N060080L001ARF,4,1.22,34.4,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",N060080L002A,N060080L002A,6,1.83,38.8,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",N060080L003A,N060080L003A,8,2.44,41.3,Comsearch's Frequency Coordination Database
 "Cambium Networks, LTD",N060080L006A,N060080L006A,6,1.83,39.5,https://www.dlmanuals.com/manual/cambium-ptp-800-series/user-manual/173
+"Cambium Networks, LTD",N060080L006B,N060080L006B,6,1.83,39.1,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",N060080L007A,N060080L007A,8,2.44,42,Comsearch's Frequency Coordination Database
+Cambium Networks,N060082D125A,N060082D125A,4,1.22,36.5,Typo should be N060082D152A
+"Cambium Networks, LTD",N060082D128,N060082D128,3,0.91,33,Comsearch's Frequency Coordination Database
 "Cambium Networks, LTD",N060082D128A,N060082D128A,3,0.91,33,https://www.ispsupplies.com/core/media/media.nl?id=7521917&c=393682&h=WmzK6TO7Dv_Trk6A4cSGbqKajbuyl2_8aOz1GrrL5w5AxAeo
+"Cambium Networks, LTD",N060082D129,N060082D129,4,1.22,35.5,Comsearch's Frequency Coordination Database
 "Cambium Networks, LTD",N060082D129A,N060082D129A,4,1.22,35,https://www.ispsupplies.com/core/media/media.nl?id=7521920&c=393682&h=2zo9IEM_D7pfnqckKLVyf1xzvAvKL6U1NNzeXoop6HCiEHyy
 CAMBIUM NETWORKS,N060082D132A,N060082D132A,6,1.83,39,https://www.ispsupplies.ca/core/media/media.nl?id=5506200&c=393682&h=BctKf_IGanF6Pzw7AhFva8pUq8JkqNdydudyQ6O-85F-yHHV
+"Cambium Networks, LTD",N060082D151,N060082D151,3,0.91,33.3,Comsearch's Frequency Coordination Database
 CAMBIUM NETWORKS,N060082D151A,N060082D151A,3,0.91,33.3,https://www.winncom.com/pdf/Cambium_N060082D151A/Cambium_N060082D151A.PDF
+"Cambium Networks, LTD",N060082D152,N060082D152,4,1.22,36.5,Comsearch's Frequency Coordination Database
 CAMBIUM NETWORKS,N060082D152A,N060082D152A,4,1.22,36.5,https://www.winncom.com/en/products/N060082D152A
-"Cambium Networks, LTD",N060082D153A,N060082D153A,4,1.22,39.3,https://www.winncom.com/en/products/N060082D152A
+"Cambium Networks, LTD",N060082D153,N060082D153,6,1.83,39.3,Comsearch's Frequency Coordination Database
+"Cambium Networks, LTD",N060082D153A,N060082D153A,6,1.83,39.3,Comsearch's Frequency Coordination Database
+NA,NA,NA,,,,Indetereminate.
+"SIAE Microelettronica,Inc",NKHPwb6L-AGS20-28M-4096Q,NKHPWB6LAGS2028M4096Q,,,,Radio - Indeterminate. 
 Mark Antennas,P060A72D,P060A72D,6,1.83,38.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+PAD10-W59A,P1-001223,P1001223,,,,Indeterminate. 
+PAD6-W59B,P1-001224,P1001224,,,,Indeterminate. 
 ANDREW,P10-186,P10186,10,3.05,44,Comsearch's Frequency Coordination Database
 COMMSCOPE,P10-186,P10186,10,3.05,44,Comsearch's Frequency Coordination Database
 ANDREW,P10-186A,P10186A,10,3.05,44,Comsearch's Frequency Coordination Database
@@ -660,6 +1013,8 @@ COMMSCOPE,p10-65c,P1065C,10,3.05,43.9,Comsearch's Frequency Coordination Databas
 ANDREW,P10-65D,P1065D,10,3.05,43.9,Comsearch's Frequency Coordination Database
 COMMSCOPE,P10-65D,P1065D,10,3.05,43.9,Comsearch's Frequency Coordination Database
 RFS,P10-65D,P1065D,10,3.05,43.9,Comsearch's Frequency Coordination Database
+Andrew Corp,P10&8-65D,P10865D,10,3.05,43.9,Used P10-65D
+CommScope,P12-57W,P1257W,12,3.66,44.6,Comsearch's Frequency Coordination Database
 ANDREW,P12-59E,P1259E,12,3.66,44.6,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 COMMSCOPE,P12-65,P1265,12,3.66,45.8,Comsearch's Frequency Coordination Database
 ANDREW,P12-65D,P1265D,12,3.66,45.6,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
@@ -668,37 +1023,49 @@ COMMSCOPE,P12-65E,P1265E,12,3.66,45.6,Comsearch's Frequency Coordination Databas
 COMMSCOPE,P4-65,P465,4,1.22,36.2,Comsearch's Frequency Coordination Database
 COMMSCOPE,P4-65C,P465C,4,1.22,36.3,Comsearch's Frequency Coordination Database
 COMMSCOPE,P4-65D,P465D,4,1.22,36.3,Comsearch's Frequency Coordination Database
+MARK ANTENNA,P-59A96,P59A96,8,2.44,41,Comsearch's Frequency Coordination Database
+Andrew Corp,P-59D,P59D,,,,Indeterminate. 
+ANDREWS,P6,P6,,,,Indeterminate.
+MARK ANTENNA,P-60120,P60120,10,3.05,43.3,Comsearch's Frequency Coordination Database
 MARK ANTENNA,P-6072,P6072,6,1.83,38.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna,P-60A120D LF,P60A120DLF,10,3.05,43.3,https://www.datasheetarchive.com/pdf/download.php?id=0480ca47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=MHP-60A72DL
 MARK ANTENNA PRODS,P-60A120D* LF,P60A120DLF,10,3.05,43.3,https://www.datasheetarchive.com/pdf/download.php?id=0480ca47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=MHP-60A72DL
 MARK ANTENNA,P-60A120D RF,P60A120DRF,10,3.05,43.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA PRODS,P-60A120L,P60A120L,10,3.05,43.3,https://www.datasheetarchive.com/pdf/download.php?id=0480ca47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=MHP-60A72DL
 Mark Antenna,P-60A120 LF,P60A120LF,10,3.05,43.3,https://www.datasheetarchive.com/pdf/download.php?id=0480ca47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=MHP-60A72DL
+Mark Antenna,P-60A120 RF,P60A120RF,10,3.05,43.3,Comsearch's Frequency Coordination Database
+Mark,P-60A144D RF,P60A144DRF,12,3.66,45,Comsearch's Frequency Coordination Database
 Mark,P-60A144 RF,P60A144RF,12,3.66,45,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA,P-60A72,P60A72,6,1.83,38.9,Comsearch's Frequency Coordination Database
 Mark Antennas,P-60A72D,P60A72D,6,1.83,38.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-60A72D LF,P60A72DLF,6,1.83,38.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNAS,P-60A72D RF,P60A72DRF,6,1.83,38.7,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNAS,P-60A72D RF,P60A72DRF,6,1.83,38.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA PROD,P-60A72 (LF),P60A72LF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNA PRODUCTS,P-60A72 LF,P60A72LF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna Prod,P-60A72(LF),P60A72LF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna Prod,p-60A72(LF),P60A72LF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA PRODUCTS,P-60A72 LF,P60A72LF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA PRODUCTS,P60A72 RF,P60A72RF,6,1.83,38.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA PRODUCTS,P-60A72 RF,P60A72RF,6,1.83,38.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antennas,P-60A72RF,P60A72RF,6,1.83,38.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-60A96,P60A96,8,2.44,41.5,https://www.datasheetarchive.com/pdf/download.php?id=0480ca47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=MHP-60A72DL
 Mark Antenna,P-60A96D,P60A96D,8,2.44,41.5,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+COMSAT RSI MARK,P-60A96D RF,P60A96DRF,8,2.44,41.5,Based on P60A96D
 Mark Antenna,P-60A96 (LF),P60A96LF,8,2.44,41.5,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna,P-60A96 LF,P60A96LF,8,2.44,41.5,https://www.datasheetarchive.com/pdf/download.php?id=0480ca47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=MHP-60A72DL
 MARK ANTENNA,P-60A96LF,P60A96LF,8,2.44,41.5,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA,P-60A96RF,P60A96RF,8,2.44,41.5,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA PRODUCTS,P 60A96 RF,P60A96RF,8,2.44,41.5,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna Products,P-60A96 RF,P60A96RF,8,2.44,41.5,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNA,P-60A96RF,P60A96RF,8,2.44,41.5,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 ANDREW,P6-25D,P625D,6,1.83,,Model does not belong in this band.
+PRODELIN CORPORATION,P64000,P64000,8,2.44,42.3,Antenna Code for 164-740
+Andrew Corp,P-65,P65,,,,Indeterminate.
+MARK ANTENNA,P-65120,P65120,10,3.05,43.9,Comsearch's Frequency Coordination Database
 Mark,P-65120W,P65120W,10,3.05,44,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA PROD,P 6572,P6572,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna,P-6572L,P6572L,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNA PROD,P 6572W,P6572W,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-6572W,P6572W,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA PROD,P 6572W,P6572W,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+Mark Products,P6572WL,P6572WL,6,1.83,39.3,Used P-6572W
 ANDREW,P6-57W,P657W,6,1.83,38.5,Comsearch's Frequency Coordination Database
 COMMSCOPE,P6-57W,P657W,6,1.83,38.5,Comsearch's Frequency Coordination Database
 ANDREW,P6-59,P659,6,1.83,38.7,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
@@ -709,79 +1076,92 @@ COMMSCOPE,P6-59C,P659C,6,1.83,38.9,Comsearch's Frequency Coordination Database
 ANDREW,P6 59D,P659D,6,1.83,38.9,Comsearch's Frequency Coordination Database
 ANDREW,P6-59D,P659D,6,1.83,38.9,Comsearch's Frequency Coordination Database
 COMMSCOPE,P6-59D,P659D,6,1.83,38.9,Comsearch's Frequency Coordination Database
+MARK ANTENNA,P-65A120D,P65A120D,10,3.05,44,Comsearch's Frequency Coordination Database
+Mark Antenna,P-65A120D LF,P65A120DLF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 Mark,P65A120 LF,P65A120LF,10,3.05,44,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-65A120 LF,P65A120LF,10,3.05,44,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna,P-65A120LF,P65A120LF,10,3.05,44,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA,P-65A120 RF,P65A120RF,10,3.05,44,Comsearch's Frequency Coordination Database
 MARK ANTENNA,P-65A144,P65A144,12,3.66,45.8,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK,P-65A48D,P65A48D,4,1.22,36.3,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNAS,P 65A72,P65A72,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-65A72,P65A72,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNAS,P 65A72,P65A72,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+ComSat RSI,P-65A72-2,P65A722,6,1.83,39.9,Based on P65A72
 MARK ANTENNA,P-65A72D LF,P65A72DLF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-65A72D RF,P65A72DRF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+Mark Antennas,P-65A72L,P65A72L,6,1.83,39.9,Based on P65A72
 MARK ANTENNA PRODUCT,P-65A72L-2,P65A72L2,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=b5514b47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=P-65A72
 Mark,P- 65A72 LF,P65A72LF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-65A72 LF,P65A72LF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA,P-65A72 LF,P65A72LF,6,1.83,39.9,Comsearch's Frequency Coordination Database
 MARK ANTENNA PROD,P-65A72LF,P65A72LF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-Mark Antenna Products,P-65A72 (RF),P65A72RF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNA PRODUCT,P-65A72 RF,P65A72RF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=b5514b47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=P-65A72
-Mark Antenna Products,P-65A72(RF),P65A72RF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna,P-65A72RF,P65A72RF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNA PRODUCTS,P 65A96,P65A96,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA PRODUCT,P-65A72 RF,P65A72RF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=b5514b47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=P-65A72
+Mark Antenna Products,P-65A72 (RF),P65A72RF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+Mark Antenna Products,P-65A72(RF),P65A72RF,6,1.83,39.9,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P65A96,P65A96,8,2.44,42.4,Comsearch's Frequency Coordination Database
+MARK ANTENNA PRODUCTS,P 65A96,P65A96,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNAS,P-65A96D,P65A96D,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-65A96D RF,P65A96DRF,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-65A96DRF,P65A96DRF,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-MARK ANTENNA PROD,P-65A96 L,P65A96L,6,1.83,42.5,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
-MARK ANTENNA PRODUCTS,P65A96L-2,P65A96L2,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA PROD,P-65A96 L,P65A96L,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 Mark Antenna,P-65A96L-2,P65A96L2,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+MARK ANTENNA PRODUCTS,P65A96L-2,P65A96L2,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-65A96 LF,P65A96LF,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=0480ca47c46d7b83326b2d8bd5ddfa66595fab&type=O&term=MHP-60A72DL
 MARK ANTENNA,P-65A96R,P65A96R,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
-Mark Antennas,P65A96 RF,P65A96RF,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
 MARK ANTENNA,P-65A96 RF,P65A96RF,8,2.44,42.4,Comsearch's Frequency Coordination Database
 MARK ANTENNA,P65A96RF,P65A96RF,8,2.44,42.4,Comsearch's Frequency Coordination Database
 Mark Antenna,P-65A96RF,P65A96RF,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+Mark Antennas,P65A96 RF,P65A96RF,8,2.44,42.4,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+Mark Antenna,P-65A96RP,P65A96RP,8,2.44,42.4,Used P-65A96 RF
 Mark Antenna,P-65AD144V MN RF,P65AD144VMNRF,12,3.66,45.8,https://www.datasheetarchive.com/pdf/download.php?id=30859147c46d7b83326b2d8bd5ddfa66595fab&type=O&term=PT-65A96
+Andrew Corp,P-65D,P65D,,,,Indeterminate. 
+Mark Antenna,P-65D144VMNRF,P65D144VMNRF,12,3.66,424,Used P-65AD144V MN RF
 ANDREW,P6-65,P665,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 COMMSCOPE,P6-65,P665,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,P6-65A,P665A,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
+CABLEWAVE SYSTEMS,P6-65B,P665B,6,1.83,39.5,Using P6-65
 ANDREW,P6-65C,P665C,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 COMMSCOPE,P6-65C,P665C,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,P6 65D,P665D,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,P6 65d,P665D,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,P6.65D,P665D,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,P6-65D,P665D,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
-COMMSCOPE,P6-65D,P665D,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,p6-65d,P665D,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
+COMMSCOPE,P6-65D,P665D,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,P6-65E,P665E,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 COMMSCOPE,P6-65E,P665E,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
-RFS,P6-65E,P665E,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 COMMSCOPE,p6-65e,P665E,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 COMMSCOPE,P6-65e,P665E,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
+RFS,P6-65E,P665E,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,P6-65J,P665J,6,1.83,39.5,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
+MARK ANTENNAS,P 6A72,P6A72,,,,Indeterminate.  P-6A72G is a 960 MHz antenna.  
 ANDREW,P8-186,P8186,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/P8-186-pdf.php
 COMMSCOPE,P8-186,P8186,8,2.44,42,Comsearch's Frequency Coordination Database
 ANDREW,P8-186 2GHZ-V,P81862GHZV,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/P8-186-pdf.php
 ANDREW,P8-186 2GHZ-V,P81862GHZV,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/P8-186-pdf.php
+ANDREW CORPORATION,P8-186 6GHZ-2V,P81866GHZ2V,8,2.44,41,Comsearch's Frequency Coordination Database
 COMMSCOPE,P8-57W,P857W,8,2.44,41.2,Comsearch's Frequency Coordination Database
 COMMSCOPE,P8-59A,P859A,8,2.44,41.5,Comsearch's Frequency Coordination Database
 COMMSCOPE,P8-59C,P859C,8,2.44,41.5,Comsearch's Frequency Coordination Database
 ANDREW,P8-59D,P859D,8,2.44,41.5,Comsearch's Frequency Coordination Database
 COMMSCOPE,P8-59D,P859D,8,2.44,41.5,Comsearch's Frequency Coordination Database
-COMMSCOPE,P8?65,P865,8,2.44,42,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
+ANDREW CORPORATION,P85-D,P85D,,,,Indeterminate
 ANDREW,P8-65,P865,8,2.44,42,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
+COMMSCOPE,P8?65,P865,8,2.44,42,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 COMMSCOPE,P8-65,P865,8,2.44,42,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,P8-65A,P865A,8,2.44,42,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,P8-65C,P865C,8,2.44,42.3,Comsearch's Frequency Coordination Database
 COMMSCOPE,P8-65C,P865C,8,2.44,42.3,Comsearch's Frequency Coordination Database
 ANDREW,P8-65D,P865D,8,2.44,42.3,Comsearch's Frequency Coordination Database
-COMMSCOPE,P8-65D,P865D,8,2.44,42.3,Comsearch's Frequency Coordination Database
 ANDREW,P8-65d,P865D,8,2.44,42.3,Comsearch's Frequency Coordination Database
 ANDREW,P8-65-D,P865D,8,2.44,42.3,Comsearch's Frequency Coordination Database
+COMMSCOPE,P8-65D,P865D,8,2.44,42.3,Comsearch's Frequency Coordination Database
 COMMSCOPE,P8-65-D,P865D,8,2.44,42.3,Comsearch's Frequency Coordination Database
 ANDREW,P8-65D A64130,P865DA64130,8,2.44,42.3,Comsearch's Frequency Coordination Database
 ANDREW,P8-65 or similar,P865ORSIMILAR,8,2.44,42.3,Comsearch's Frequency Coordination Database
-RFS/Cablewave,PA1059,PA1059,10,3.05,43.4,Comsearch's Frequency Coordination Database
 RFS,PA10-59,PA1059,10,3.05,43.4,Comsearch's Frequency Coordination Database
+RFS/Cablewave,PA1059,PA1059,10,3.05,43.4,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PA10-59A,PA1059A,10,3.05,43.4,Comsearch's Frequency Coordination Database
 RFS,PA10-59A,PA1059A,10,3.05,43.4,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PA10-59AC,PA1059AC,10,3.05,43.4,Comsearch's Frequency Coordination Database
@@ -796,23 +1176,27 @@ RFS,PA10-W57A,PA10W57A,10,3.05,43.5,Comsearch's Frequency Coordination Database
 RFS,PA10-W57A (P),PA10W57AP,10,3.05,43.5,Comsearch's Frequency Coordination Database
 RFS/Cablewave,PA10W59,PA10W59,10,3.05,43.6,https://www.rfsworld.com/userfiles/pdf/287a.pdf
 RFS,PA10-W59A,PA10W59A,10,3.05,43.6,Comsearch's Frequency Coordination Database
-RFS/Cablewave,PA1259,PA1259,12,3.66,45.1,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PA12-59,PA1259,12,3.66,45.1,Comsearch's Frequency Coordination Database
+RFS/Cablewave,PA1259,PA1259,12,3.66,45.1,Comsearch's Frequency Coordination Database
 RFS,PA12-65,PA1265,12,3.66,45.8,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PA12-65A,PA1265A,12,3.66,45.8,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PA12-65AC,PA1265AC,12,3.66,45.8,Comsearch's Frequency Coordination Database
 RFS/Cablewave,PA12W59,PA12W59,12,3.66,45.2,https://www.rfsworld.com/userfiles/pdf/287a.pdf
 RFS,PA12-W59A,PA12W59A,12,3.66,45.2,Comsearch's Frequency Coordination Database
+ANDREW CORPORATION,PA48-59,PA4859,,,,Indeterminate
 RFS,PA4-W57A,PA4W57A,4,1.22,35.5,Comsearch's Frequency Coordination Database
+CABLEWAVE SYSTEMS,PA6065,PA6065,,,,Indeterminate
+Comcast-RSI,PA-60A72,PA60A72,6,1.83,38.9,Assumed to be P60A72
 CABLEWAVE SYSTEMS,PA6-54B,PA654B,6,1.83,,Indeterminate. Band designator 54 has multiple options. 
-RFS/Cablewave,PA659,PA659,6,1.83,39.2,https://www.rfsworld.com/userfiles/pdf/287a.pdf
-CABLEWAVE SYSTEMS,PA6-59,PA659,6,1.83,39.2,https://www.rfsworld.com/userfiles/pdf/287a.pdf
+CABLEWAVE SYSTEMS,PA6-59,PA659,6,1.83,39,Comsearch's Frequency Coordination Database
+RFS/Cablewave,PA659,PA659,6,1.83,39,Comsearch's Frequency Coordination Database
 RFS,PA6-59A,PA659A,6,1.83,39,Comsearch's Frequency Coordination Database
 RFS,PA6-59B,PA659B,6,1.83,39,Comsearch's Frequency Coordination Database
 ANDREW,PA6-59W,PA659W,6,1.83,39.2,https://www.rfsworld.com/userfiles/pdf/287a.pdf
 CABLEWAVE SYSTEMS,PA6-59W,PA659W,6,1.83,39.2,Comsearch's Frequency Coordination Database
-CABLEWAVE SYSTEMS,PA6 65,PA665,6,1.83,39.9,Comsearch's Frequency Coordination Database
+CABLEWAVE SYSTEMS,PA65B,PA65B,,,,Indeterminate. 
 ANDREW,PA6-65,PA665,6,1.83,39.9,Comsearch's Frequency Coordination Database
+CABLEWAVE SYSTEMS,PA6 65,PA665,6,1.83,39.9,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PA6-65,PA665,6,1.83,39.9,Comsearch's Frequency Coordination Database
 RFS,PA6-65,PA665,6,1.83,39.9,Comsearch's Frequency Coordination Database
 ANDREW,PA6-65A,PA665A,6,1.83,39.9,Comsearch's Frequency Coordination Database
@@ -828,16 +1212,16 @@ RFS,PA6-W57B,PA6W57B,6,1.83,39,Comsearch's Frequency Coordination Database
 RFS/Cablewave,PA6W59,PA6W59,6,1.83,39.2,https://www.rfsworld.com/userfiles/pdf/287a.pdf
 RFS,PA6-W59A,PA6W59A,6,1.83,39.2,Comsearch's Frequency Coordination Database
 RFS,PA6-W59B,PA6W59B,6,1.83,39.2,Comsearch's Frequency Coordination Database
-RFS/Cablewave,PA859,PA859,8,2.44,41.7,https://www.rfsworld.com/userfiles/pdf/287a.pdf
-CABLEWAVE SYSTEMS,PA8-59,PA859,8,2.44,41.7,https://www.rfsworld.com/userfiles/pdf/287a.pdf
+CABLEWAVE SYSTEMS,PA8-59,PA859,8,2.44,41.6,Comsearch's Frequency Coordination Database
+RFS/Cablewave,PA859,PA859,8,2.44,41.6,Comsearch's Frequency Coordination Database
 RFS,PA8-59A,PA859A,8,2.44,41.6,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PA8-59B,PA859B,8,2.44,41.6,Comsearch's Frequency Coordination Database
 RFS,PA8-59B,PA859B,8,2.44,41.6,Comsearch's Frequency Coordination Database
-ANDREW,PA8-65,PA865,8,2.44,41.7,https://www.rfsworld.com/userfiles/pdf/287a.pdf
-CABLEWAVE SYSTEMS,PA8-65,PA865,8,2.44,41.7,https://www.rfsworld.com/userfiles/pdf/287a.pdf
-RFS,PA8-65,PA865,8,2.44,41.7,https://www.rfsworld.com/userfiles/pdf/287a.pdf
-RFS,PA8?65A,PA865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
+ANDREW,PA8-65,PA865,8,2.44,42.4,"https://www.rfsworld.com/userfiles/pdf/287a.pdf << Invalid page, wrong band. "
+CABLEWAVE SYSTEMS,PA8-65,PA865,8,2.44,42.4,"https://www.rfsworld.com/userfiles/pdf/287a.pdf << Invalid page, wrong band. "
+RFS,PA8-65,PA865,8,2.44,42.4,"https://www.rfsworld.com/userfiles/pdf/287a.pdf << Invalid page, wrong band. "
 CABLEWAVE SYSTEMS,PA8-65A,PA865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
+RFS,PA8?65A,PA865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
 RFS,PA8-65A,PA865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PA8-65AC,PA865AC,8,2.44,42.4,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PA8-65B,PA865B,8,2.44,42.4,Comsearch's Frequency Coordination Database
@@ -849,6 +1233,7 @@ RFS,PA8-W59A,PA8W59A,8,2.44,41.7,Comsearch's Frequency Coordination Database
 RFS,PAA8-65A,PAA865A,8,2.44,,Indeterminate. Third character has multiple options. 
 ANDREW,PAAR8-59W RF,PAAR859WRF,8,2.44,41,https://objects.eanixter.com/PD355687.PDF
 COMMSCOPE,PAARX8-59WA,PAARX859WA,8,2.44,40.7,https://objects.eanixter.com/PD376733.PDF
+RFS Cablewave,PAD10,PAD10,10,3.05,,Band indeterminate. 
 RFS,PAD10-50A,PAD1050A,10,3.05,43.2,https://www.rfsworld.com/pim/product/html/PAD10-59AC
 CABLEWAVE SYSTEMS,PAD10-59,PAD1059,10,3.05,43.2,https://www.rfsworld.com/pim/product/html/PAD10-59AC
 RFS,PAD10-59,PAD1059,10,3.05,43.2,https://www.rfsworld.com/pim/product/html/PAD10-59AC
@@ -862,16 +1247,20 @@ CABLEWAVE SYSTEMS,PAD10-65AC,PAD1065AC,10,3.05,43.9,https://www.rfsworld.com/pim
 RFS,PAD10-W57A,PAD10W57A,10,3.05,43.5,https://www.rfsworld.com/pim/product/html/PAD10-W57AC
 RFS,PAD10-W59A,PAD10W59A,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/PAD10-W59AC
 RFS,PAD1-65A,PAD165A,10,3.05,43.9,http://www.dadehnama.ir/uploads/4_313508659575390274.pdf
+RFS,PAD-59,PAD59,,,,Indeterminate. 
+RFS,PAD-59A,PAD59A,,,,Indeterminate. 
+CABLEWAVE SYSTEMS,PAD6065AC,PAD6065AC,6,1.83,39.6,Using PAD6-65AC
 RFS,PAD6-107A,PAD6107A,,,,Model does not belong in this band.
 RFS,PAD6-259B,PAD6259B,6,1.83,,Indeterminate. Band designator 259 is not known. 
+CABLEWAVE SYSTEMS,PAD-65,PAD65,,,,Indeterminate.
 CABLEWAVE SYSTEMS,PAD6-50AC,PAD650AC,6,1.83,,Indeterminate. Band designator 50 has multiple options. 
 RFS,PAD6-57B,PAD657B,6,1.83,,Indeterminate. Band designator 57 is unknown. 
 CABLEWAVE SYSTEMS,PAD6-57W,PAD657W,6,1.83,,Indeterminate. Band designator 57 is unknown. 
 RFS,PAD6-57WA,PAD657WA,6,1.83,,Indeterminate. Band designator 57 is unknown. 
 CABLEWAVE SYSTEMS,PAD6-59,PAD659,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
 RFS,PAD6-59,PAD659,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
-RFS,PAD6?59A,PAD659A,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
 CABLEWAVE SYSTEMS,PAD6-59A,PAD659A,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
+RFS,PAD6?59A,PAD659A,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
 RFS,PAD6-59A,PAD659A,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
 CABLEWAVE SYSTEMS,PAD6-59AC,PAD659AC,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
 RFS,PAD6-59B,PAD659B,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
@@ -879,11 +1268,14 @@ RFS,PAD-6-59B,PAD659B,6,1.83,38.7,http://www.dadehnama.ir/uploads/4_313508659575
 RFS,PAD6-59N,PAD659N,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
 CABLEWAVE SYSTEMS,PAD6-59W,PAD659W,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
 RFS,PAD6-59WW,PAD659WW,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PAD6-59BC
+RFS,PAD65A,PAD65A,,,,Indeterminate. 
+RFS,PAD-65A,PAD65A,,,,Indeterminate. 
+RFS,PAD65AC,PAD65AC,,,,Indeterminate. 
 CABLEWAVE SYSTEMS,PAD6-65,PAD665,6,1.83,39.6,https://www.rfsworld.com/pim/product/html/PAD6-65BC
 RFS,PAD6-65,PAD665,6,1.83,39.6,https://www.rfsworld.com/pim/product/html/PAD6-65BC
-RFS,PAD665A,PAD665A,6,1.83,39.6,https://www.rfsworld.com/pim/product/html/PAD6-65BC
 ANDREW,PAD6-65A,PAD665A,6,1.83,39.6,https://docplayer.net/44808769-Microwave-antenna-systems.html
 CABLEWAVE SYSTEMS,PAD6-65A,PAD665A,6,1.83,39.6,Comsearch's Frequency Coordination Database
+RFS,PAD665A,PAD665A,6,1.83,39.6,https://www.rfsworld.com/pim/product/html/PAD6-65BC
 RFS,PAD6-65A,PAD665A,6,1.83,39.6,https://www.rfsworld.com/pim/product/html/PAD6-65BC
 RFS,PAd6-65A,PAD665A,6,1.83,39.6,https://www.rfsworld.com/pim/product/html/PAD6-65BC
 CABLEWAVE SYSTEMS,PAD6-65AC,PAD665AC,6,1.83,39.6,https://www.rfsworld.com/pim/product/html/PAD6-65BC
@@ -893,19 +1285,23 @@ RFS,PAD6-65B,PAD665B,6,1.83,39.6,https://www.rfsworld.com/pim/product/html/PAD6-
 RFS,PAD6-65BC,PAD665BC,6,1.83,39.6,https://www.rfsworld.com/pim/product/html/PAD6-65BC
 RFS,PAD6-65D,PAD665D,6,1.83,39.6,https://www.rfsworld.com/pim/product/html/PAD6-65BC
 RFS,PAD6-69A,PAD669A,6,1.83,39.6,Typo should be PAD665A. Using that gain. 
+RFS,PAD6-U57A,PAD6U57A,6,1.83,38.9,https://alliancecorporation.ca/images/documents/wireless-infrastructure-documents/RFS/Microwave_antennas/Alliance_distributor_RFS_Microwave_Antenna_PADX6-U57AC.pdf
 RFS,PAD6-W57A,PAD6W57A,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PAD6-W57BC
 RFS,PAD6W57B,PAD6W57B,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PAD6-W57BC
 RFS,PAD6w57B,PAD6W57B,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PAD6-W57BC
 RFS,PAD6-W57B,PAD6W57B,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PAD6-W57BC
 RFS,PAD6-w57B,PAD6W57B,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PAD6-W57BC
+RFS,PAD6-W57BC1S1R,PAD6W57BC1S1R,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PAD6-W57BC
 RFS,PAD6-W57G,PAD6W57G,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PAD6-W57BC
 RFS,PAD6-W59A,PAD6W59A,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/PAD6-W59BC
 ANDREW,PAD6-W59B,PAD6W59B,6,1.83,39.1,https://www.rfsworld.com/userfiles/pdf/6ghz_aws_relocation_kit.pdf
 COMMSCOPE,PAD6-W59B,PAD6W59B,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/PAD6-W59BC
 RFS,PAD6-W59B,PAD6W59B,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/PAD6-W59BC
+RFS,PAD6-W60D,PAD6W60D,6,1.83,,Indeterminate. Band designator 60 not known. 
+RFS,PAD8,PAD8,8,2.44,,8 foot antenna. Various bands  have gain ranges of 41.3 - 42.1
 RFS,PAD8-57A,PAD857A,8,2.44,,Indeterminate. Band designator 57 is unknown. 
-RFS,PAD8 57W,PAD857W,8,2.44,41.4,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAD8-57W,PAD857W,8,2.44,41.4,Comsearch's Frequency Coordination Database
+RFS,PAD8 57W,PAD857W,8,2.44,41.4,Comsearch's Frequency Coordination Database
 RFS,PAD8-58A,PAD858A,8,2.44,,Indeterminate. Band designator 58 is unknown. 
 CABLEWAVE SYSTEMS,PAD8-59,PAD859,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/PAD8-59AC
 RFS,PAD8-59,PAD859,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/PAD8-59AC
@@ -915,15 +1311,16 @@ RFS,PAD8-59AC,PAD859AC,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/PAD
 CABLEWAVE SYSTEMS,PAD8-59W,PAD859W,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/PAD8-59AC
 CABLEWAVE SYSTEMS,PAD8-59WAC,PAD859WAC,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/PAD8-59AC
 RFS,PAD8-59WW,PAD859WW,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/PAD8-59AC
-RFS,PAD8-5(A,PAD85A,6,1.83,41.3,https://www.rfsworld.com/pim/product/html/PAD8-59AC
+RFS,PAD8-5(A,PAD85A,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/PAD8-59AC
 CABLEWAVE SYSTEMS,PAD8-65,PAD865,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
-RFS,PAD8.65A,PAD865A,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
 CABLEWAVE SYSTEMS,PAD8-65A,PAD865A,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
+RFS,PAD8.65A,PAD865A,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
 RFS,PAD8-65A,PAD865A,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
 RFS,PAD8-65a,PAD865A,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
-RFS,PAD8 65AC,PAD865AC,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
 CABLEWAVE SYSTEMS,PAD8-65AC,PAD865AC,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
+RFS,PAD8 65AC,PAD865AC,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
 RFS,PAD8-65AC,PAD865AC,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
+CABLEWAVE SYSTEMS,PAD8-65/PAD6-65,PAD865PAD665,8,2.44,42.1,https://www.rfsworld.com/pim/product/html/PAD8-65AC
 RFS,PAD8-U57A,PAD8U57A,8,2.44,41.4,Typo should be PAD8W57A. Using that gain. 
 RFS,PAD8-W159A,PAD8W159A,8,2.44,41.6,Typo should be PAD8W59A. Using that gain. 
 RFS,PAD8-W57,PAD8W57,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PAD8-W57AC
@@ -932,16 +1329,20 @@ RFS,PAD8-W57A,PAD8W57A,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PAD
 RFS,PAD8-W57B,PAD8W57B,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PAD8-W57AC
 RFS,PAD8-W59A,PAD8W59A,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/PAD8-W59AC
 RFS,PAD8-W59W,PAD8W59W,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/PAD8-W59AC
+RFS,PAD9-59B,PAD959B,,,,Diameter indeterminate
+RFS,PAD-95AC,PAD95AC,,,,Indeterminate. 
 RFS,PAD^-W59B,PADW59B,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/PAD6-W59BC
+RFS,PADX10-59A,PADX1059A,10,3.06,43.1,Comsearch's Frequency Coordination Database
 RFS,PADX10-59W,PADX1059W,10,3.05,43.4,Comsearch's Frequency Coordination Database
 RFS,PADX10-65A,PADX1065A,10,3.05,43.9,Comsearch's Frequency Coordination Database
 RFS,PADX10-U57A,PADX10U57A,10,3.05,43.2,https://www.rfsworld.com/pim/product/html/PADX10-U57AC
-RFS,PADX10-W57A,PADX10W57A,10,3.05,43.4,Comsearch's Frequency Coordination Database
 COMMSCOPE,PADX10--W57A,PADX10W57A,10,3.05,43.4,Comsearch's Frequency Coordination Database
+RFS,PADX10-W57A,PADX10W57A,10,3.05,43.4,Comsearch's Frequency Coordination Database
 RFS,PADX10-W59A,PADX10W59A,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/PADX10-W59AC
 RFS,PADX10-W65A,PADX10W65A,10,3.05,43.9,https://alliancecorporation.ca/images/documents/wireless-infrastructure-documents/RFS/Microwave_antennas/Alliance_distributor_RFS_Microwave_Antenna_PAD10-65AC.pdf
+RFS,PADX-59A,PADX59A,,,,Indeterminate. 
 RFS,PADX6-59,PADX659,6,1.83,38.1,https://www.rfsworld.com/pim/product/html/PADX6-59BC1S1R
-RFS,PADX6-59A,PADX659A,6,1.83,38.5,https://www.rfsworld.com/pim/product/html/PADX6-59BC1S1R
+RFS,PADX6-59A,PADX659A,6,1.83,38.1,https://www.rfsworld.com/pim/product/html/PADX6-59BC1S1R
 RFS,PADX6-59B,PADX659B,6,1.83,38.1,https://www.rfsworld.com/pim/product/html/PADX6-59BC1S1R
 CABLEWAVE SYSTEMS,PADX6-59WAC,PADX659WAC,6,1.83,38.9,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PADX6-59WAC 43015C,PADX659WAC43015C,6,1.83,38.9,Comsearch's Frequency Coordination Database
@@ -953,26 +1354,27 @@ RFS,PADX6-W57A,PADX6W57A,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/P
 RFS,PADX6-W57AC,PADX6W57AC,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/PADX6-W57AC
 ANDREW,PADX6-W59,PADX6W59,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PADX6-W59BC
 RFS,PADX6-W59A,PADX6W59A,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PADX6-W59BC
+COMMSCOPE,PADX6-W59B,PADX6W59B,6,1.83,38.9,Comsearch's Frequency Coordination Database
 RFS,PADX6 W59 B,PADX6W59B,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PADX6-W59BC
 RFS,PADX6 W59B,PADX6W59B,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PADX6-W59BC
 RFS,PADX6?¡W59B,PADX6W59B,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PADX6-W59BC
 RFS,PADX6W59B,PADX6W59B,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PADX6-W59BC
-COMMSCOPE,PADX6-W59B,PADX6W59B,6,1.83,38.9,Comsearch's Frequency Coordination Database
 RFS,PADX6-W59B,PADX6W59B,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PADX6-W59BC
 RFS,PADX6-W59BC,PADX6W59BC,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PADX6-W59BC
+RFS,PADX6-W59BRF,PADX6W59BRF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/PADX6-W59BC
 RFS,PADX8-59A,PADX859A,8,2.44,41.1,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PADX8-59W,PADX859W,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
 CABLEWAVE SYSTEMS,PADX8-59W 44017C,PADX859W44017C,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
 CABLEWAVE SYSTEMS,PADX8-59WAC,PADX859WAC,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
 RFS,PADX8-59WAC,PADX859WAC,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
-CABLEWAVE SYSTEMS,PADX8-59WAC 44017C,PADX859WAC44017C,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
-CABLEWAVE SYSTEMS,PADX8-59WAC 44017C,PADX859WAC44017C,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
 Andrew Corporation,PADX8-59WAC 44017C,PADX859WAC44017C,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
-ANDREW CORPORATION,PADX8-65,PADX865,8,2.44,39.6,https://www.launch3telecom.com/shared_media/pdf/manufacturers/rfs_6.pdf
+CABLEWAVE SYSTEMS,PADX8-59WAC 44017C,PADX859WAC44017C,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
+CABLEWAVE SYSTEMS,PADX8-59WAC 44017C,PADX859WAC44017C,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
+ANDREW CORPORATION,PADX8-65,PADX865,8,2.44,41.9,https://www.launch3telecom.com/shared_media/pdf/manufacturers/rfs_6.pdf <<< this link doesn't reference PADX8-65.
 RFS,PADX8-65A,PADX865A,8,2.44,41.9,Comsearch's Frequency Coordination Database
 RFS,PADX8-U57,PADX8U57,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-U57AC
-RFS,PADX8?U57A,PADX8U57A,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-U57AC
 COMMSCOPE,PADX8-U57A,PADX8U57A,8,2.44,41.4,Comsearch's Frequency Coordination Database
+RFS,PADX8?U57A,PADX8U57A,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-U57AC
 RFS,PADX8-U57A,PADX8U57A,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-U57AC
 RFS,padx8-u57a,PADX8U57A,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-U57AC
 RFS,PADX8-W571,PADX8W571,8,2.44,41.2,https://www.rfsworld.com/pim/product/html/PADX8-W57AC
@@ -982,8 +1384,11 @@ RFS,PADX8-W57A,PADX8W57A,8,2.44,41.2,https://www.rfsworld.com/pim/product/html/P
 RFS,PADx8-W57A,PADX8W57A,8,2.44,41.2,https://www.rfsworld.com/pim/product/html/PADX8-W57AC
 RFS,PADX8-W59A,PADX8W59A,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
 ,PADx8-W59A,PADX8W59A,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
+RFS,PADX8-W5A,PADX8W5A,8,2.44,,Band indeterminate. 
 RFS,PADX8-W69A,PADX8W69A,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-W59AC
 RFS,PADX8-WA57A,PADX8WA57A,8,2.44,41.2,https://www.rfsworld.com/pim/product/html/PADX8-W57AC
+RFS,PADX-U57A,PADXU57A,,,,Diameter indeterminate
+RFS,PADX-W59B,PADXW59B,,,,Indeterminate
 RFS,PADZ8-U57A,PADZ8U57A,8,2.44,41.4,Typo should be PADX8U57A. Using that gain
 COMMSCOPE,PAE10-59A,PAE1059A,10,3.05,43.4,Typo should be PAL1059A. Using that gain.
 CABLEWAVE SYSTEMS,PAL10-59,PAL1059,10,3.05,43.4,Comsearch's Frequency Coordination Database
@@ -993,6 +1398,7 @@ RFS,PAL10-59A,PAL1059A,10,3.05,43.4,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL10-65,PAL1065,10,3.05,44.1,Comsearch's Frequency Coordination Database
 RFS,PAL10-65A,PAL1065A,10,3.05,44.1,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL10-65AC,PAL1065AC,10,3.05,44.1,Comsearch's Frequency Coordination Database
+CABLEWAVE,PAL12-65,PAL1265,12,3.66,45.8,Assumed to be PAL12-65A
 RFS,PAL12-65A,PAL1265A,12,3.66,45.8,Comsearch's Frequency Coordination Database
 RFS,PAL12-65AC,PAL1265AC,12,3.66,45.8,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL6-59,PAL659,6,1.83,39,Comsearch's Frequency Coordination Database
@@ -1007,29 +1413,31 @@ RFS,PAL6-65AC,PAL665AC,6,1.83,39.9,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL6-65B,PAL665B,6,1.83,39.9,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL6-65B (FCC 91550),PAL665BFCC91550,6,1.83,39.9,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL6-65B (FCC S91550),PAL665BFCCS91550,6,1.83,39.9,Comsearch's Frequency Coordination Database
-CABLEWAVE SYSTEMS,PAL8-17,PAL817,8,2.44,39.9,Comsearch's Frequency Coordination Database
+CABLEWAVE SYSTEMS,PAL8-17,PAL817,8,2.44,,Model does not belong in this band.
 CABLEWAVE SYSTEMS,PAL8-59A,PAL859A,8,2.44,41.6,Comsearch's Frequency Coordination Database
 RFS,PAL8-59A,PAL859A,8,2.44,41.6,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL8-59AC,PAL859AC,8,2.44,41.6,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL8-59B,PAL859B,8,2.44,41.6,Comsearch's Frequency Coordination Database
 RFS,PAL8-59B,PAL859B,8,2.44,41.6,Comsearch's Frequency Coordination Database
-RFS,PAL 8-65,PAL865,8,2.44,42.4,https://docplayer.net/44808769-Microwave-antenna-systems.html
 CABLEWAVE SYSTEMS,PAL8-65,PAL865,8,2.44,42.4,Comsearch's Frequency Coordination Database
+RFS,PAL 8-65,PAL865,8,2.44,42.4,https://docplayer.net/44808769-Microwave-antenna-systems.html
 RFS,PAL8-65,PAL865,8,2.44,42.4,Comsearch's Frequency Coordination Database
-RFS,PAL8 - 65 A,PAL865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL8 65A,PAL865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
-RFS,PAL8-65 A,PAL865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL8-65.A,PAL865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAL8-65A,PAL865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
+RFS,PAL8 - 65 A,PAL865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
+RFS,PAL8-65 A,PAL865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
 RFS,PAL8-65A,PAL865A,8,2.44,42.4,Comsearch's Frequency Coordination Database
 RFS,PAL8-65a,PAL865A,8,2.44,42.4,https://docplayer.net/44808769-Microwave-antenna-systems.html
 CABLEWAVE SYSTEMS,PAL8-65AC,PAL865AC,8,2.44,42.4,https://docplayer.net/44808769-Microwave-antenna-systems.html
 RFS,PAL8-65AD,PAL865AD,8,2.44,42.4,https://docplayer.net/44808769-Microwave-antenna-systems.html
+Cablewave,PA/PAL8-65.A,PAPAL865A,8,2.44,42.4,https://docplayer.net/44808769-Microwave-antenna-systems.html
+Cablewave,PA/PAL8-65A,PAPAL865A,8,2.44,42.4,https://docplayer.net/44808769-Microwave-antenna-systems.html
 ANDREW,PAR 10-59,PAR1059,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR10-59,PAR1059,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR10-59,PAR1059,10,3.05,43.2,Comsearch's Frequency Coordination Database
-COMMSCOPE,PAR 10-59A,PAR1059A,10,3.05,43.2,Comsearch's Frequency Coordination Database
 ANDREW,PAR10-59A,PAR1059A,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR 10-59A,PAR1059A,10,3.05,43.2,Comsearch's Frequency Coordination Database
 COMMSCOPE,PAR10-59A,PAR1059A,10,3.05,43.2,Comsearch's Frequency Coordination Database
 COMMSCOPE,PAr10-59A,PAR1059A,10,3.05,43.2,Comsearch's Frequency Coordination Database
 ANDREW,PAR10-59A RF,PAR1059ARF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1050,21 +1458,25 @@ COMMSCOPE,PAR10-59W (V) RF,PAR1059WVRF,10,3.05,43.4,https://www.digchip.com/data
 COMMSCOPE,PAR10-59W (V)RF,PAR1059WVRF,10,3.05,43.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR10-59W (V)RF,PAR1059WVRF,10,3.05,43.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Commscope,PAR10-59W (V)RF,PAR1059WVRF,10,3.05,43.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR1065,PAR1065,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR10-65,PAR1065,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR1065,PAR1065,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+Andrew Corp,PAR10&6-59A RF,PAR10659ARF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 RFS,PAR10-65A,PAR1065A,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR10-65A-RF,PAR1065ARF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR10-65B RF,PAR1065BRF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR10-65B RF,PAR1065BRF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR10-65 LF,PAR1065LF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR 10-65 RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR 10-65RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR10-65 RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR10-65 RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR10-65 RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR10-65RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR10-65-RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR 10-65 RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR 10-65RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR10-65 RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR10-65-RF,PAR1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+Andrew Corp,PAR10&8-59A RF,PAR10859ARF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corp,PAR10&8-59W,PAR10859W,10,3.05,43.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+RFS,PAR10-W59A,PAR10W59A,10,3.05,43.4,Assuming -59W
 ANDREW CORPORATION,PAR12-59,PAR1259,12,3.66,44.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR12-59A,PAR1259A,12,3.66,44.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR12-59A,PAR1259A,12,3.66,44.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1078,6 +1490,13 @@ ANDREW,PAR12-65A,PAR1265A,12,3.66,45.3,https://www.digchip.com/datasheets/parts/
 ANDREW,PAR12-65A (FCC 52430A),PAR1265AFCC52430A,12,3.66,45.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR12-65A RF,PAR1265ARF,12,3.66,45.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR12-65A RF,PAR1265ARF,12,3.66,45.3,Comsearch's Frequency Coordination Database
+ANDREW CORPORATION,PAR5-65A,PAR565A,,,,Diameter indeterminate
+Andrew Corp,PAR-59A,PAR59A,,,,Indeterminate. 
+Andrew Corp,PAR--59A,PAR59A,,,,Indeterminate. 
+Andrew Corp,PAR-59W,PAR59W,,,,Indeterminate. 
+COMMSCOPE,PAR-59WA RF,PAR59WARF,,,,Indeterminate. 
+ANDREW CORPORATION,PAR-59W R,PAR59WR,,,,Indeterminate. 
+Andrew Corp,PAR-59W RF,PAR59WRF,,,,Indeterminate. 
 ANDREW,PAR6059,PAR6059,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6065A,PAR6065A,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6065B RF,PAR6065BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
@@ -1092,16 +1511,16 @@ ANDREW,PAR6-59,PAR659,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datas
 CABLEWAVE SYSTEMS,PAR6-59,PAR659,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59,PAR659,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59A,PAR659A,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR6-59A,PAR659A,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59a,PAR659A,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59A`,PAR659A,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR6-59A,PAR659A,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6 59A RF,PAR659ARF,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59A RF,PAR659ARF,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59A rf,PAR659ARF,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59AWA (V)RF,PAR659AWAVRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,PAR6-59B,PAR659B,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6?59B,PAR659B,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR659B,PAR659B,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW,PAR6-59B,PAR659B,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59B,PAR659B,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAr6-59B,PAR659B,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59D,PAR659D,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1116,18 +1535,18 @@ ANDREW,PAR6-59W,PAR659W,6,1.83,38.7,https://www.digchip.com/datasheets/parts/dat
 COMMSCOPE,PAR6-59W,PAR659W,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,par6-59w,PAR659W,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6 59WA,PAR659WA,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR659WA,PAR659WA,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59WA,PAR659WA,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR659WA,PAR659WA,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59WA,PAR659WA,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59WA (H),PAR659WAH,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59WA (H),PAR659WAH,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59WA LF,PAR659WALF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR6-59 WA RF,PAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59WA RF,PAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR6-59WA RF,PAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR6-59WA RF,PAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59Wa RF,PAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59WARF,PAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR6-59 WA RF,PAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR6-59WA RF,PAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR6-59WA RF,PAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59WARF,PAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59WA RF16.7,PAR659WARF167,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59WARF (V-POL ONLY),PAR659WARFVPOLONLY,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1142,20 +1561,21 @@ COMMSCOPE,PAR6-59WA (V)RF,PAR659WAVRF,6,1.83,38.7,https://www.digchip.com/datash
 Commscope,PAR6-59WA (V)RF,PAR659WAVRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59WA(V) RF,PAR659WAVRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59WA(V)RF,PAR659WAVRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR6- 59W LF,PAR659WLF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,PAR6-59WB,PAR659WB,6,1.83,38.7,Using PAR6-59W
 ANDREW,PAR6-59W LF,PAR659WLF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR6- 59W LF,PAR659WLF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59W LF,PAR659WLF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59W LF,PAR659WLF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59W R,PAR659WR,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR 6-59W RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59W RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59W RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR6-59W RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR6-59W RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,Par6-59W RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59-W RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59WRF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR6-59W-RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR6-59W RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR6-59W RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR6-59W-RF,PAR659WRF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR^-65A,PAR65A,,,,No diameter available in the model so cannot discern proper gain
 ANDREW,PAR-65A,PAR65A,,,,No diameter available in the model so cannot discern proper gain
@@ -1169,51 +1589,52 @@ ANDREW,PAR 6-65,PAR665,6,1.83,38.8,https://www.digchip.com/datasheets/parts/data
 ANDREW,PAR6/65,PAR665,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65,PAR665,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65`,PAR665,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-ANDREW,PAR6&6-59W,PAR6659W,6,1.83,38.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,PAR6&6-59W,PAR6659W,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR 6-65A,PAR665A,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6 65A,PAR665A,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6.65A,PAR665A,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65A,PAR665A,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR6-65A,PAR665A,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,par6-65a,PAR665A,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR6-65A,PAR665A,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65A L,PAR665AL,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6 65A LF,PAR665ALF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR6-65 A LF,PAR665ALF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,PAR6-65A LF,PAR665ALF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR6-65 A LF,PAR665ALF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,PAR6-65A LF,PAR665ALF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,PAR6-65A R,PAR665AR,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6 65A RF,PAR665ARF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR6- 65A RF,PAR665ARF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,PAR6-65A (RF),PAR665ARF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65A RF,PAR665ARF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65A RF,PAR665ARF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65A RF,PAR665ARF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR6-65A RF,PAR665ARF,6,1.83,38.8,Comsearch's Frequency Coordination Database
-COMMSCOPE,PAR6-65A RF,PAR665ARF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,PAr6-65a rf,PAR665ARF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65A rf,PAR665ARF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65A Rf,PAR665ARF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65A(RF),PAR665ARF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR6-65A(RF),PAR665ARF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,PAR6-65A-RF,PAR665ARF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR6- 65A RF,PAR665ARF,6,1.83,38.8,Comsearch's Frequency Coordination Database
+COMMSCOPE,PAR6-65A RF,PAR665ARF,6,1.83,38.8,Comsearch's Frequency Coordination Database
+COMMSCOPE,PAR6-65A RF,PAR665ARF,6,1.83,38.8,Comsearch's Frequency Coordination Database
+COMMSCOPE,PAR6-65A(RF),PAR665ARF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,PAR6-65A RF6,PAR665ARF6,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65A RF6.1,PAR665ARF61,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR6-65A RFwqik561,PAR665ARFWQIK561,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR665B,PAR665B,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65B,PAR665B,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR665B,PAR665B,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR6-65B,PAR665B,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65B LF,PAR665BLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR6-65B LF,PAR665BLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6 65B RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR6 65B RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65B RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR6-65B RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAr6-65B RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,Par6-65B RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65B-RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR6 65B RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR6-65B RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,Par6-65B RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR6-65B-RF,PAR665BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR6-65B RG,PAR665BRG,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65F RF,PAR665FRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR6 65G RF,PAR665GRF,6,1.83,38.8,Using PAR6-65F RF
 ANDREW,PAR6-65 LF,PAR665LF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR6-65 LF,PAR665LF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65-PXA,PAR665PXA,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
@@ -1224,12 +1645,14 @@ ANDREW,PAR6-65 R,PAR665R,6,1.83,38.8,https://www.digchip.com/datasheets/parts/da
 ANDREW,PAR6 65 RF,PAR665RF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65 RF,PAR665RF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65 RF,PAR665RF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+ANDREW,PAR6-65RF,PAR665RF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR6-65 RF,PAR665RF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 Commscope,PAR-6-65 RF,PAR665RF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-ANDREW,PAR6-65RF,PAR665RF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-65W RF,PAR665WRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR6-69,PAR669,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 RFS,PAR6-W57B,PAR6W57B,6,1.83,38.9,Typo should be PAD6W57B. Using that gain.
+RFS,PAR6-W59B,PAR6W59B,6,1.83,38.7,Typo should be PAR6W59B. Using that gain. 
+Andrew Corp,PAR6X-59W,PAR6X59W,,,,Indeterminate. 
 ANDREW,PAR8065B LF,PAR8065BLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-50A,PAR850A,8,2.44,,Indeterminate. Band designator 50 has multiple options. 
 COMMSCOPE,PAR8-50W (H),PAR850WH,8,2.44,,Indeterminate. Band designator 50 has multiple options. 
@@ -1241,18 +1664,20 @@ ANDREW,PAR8-59,PAR859,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datas
 COMMSCOPE,PAR8-59,PAR859,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8=59A,PAR859A,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8-59A,PAR859A,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR8-59A,PAR859A,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-RFS,PAR8-59A,PAR859A,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,Par8-59A,PAR859A,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8--59A,PAR859A,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR8-59A,PAR859A,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+RFS,PAR8-59A,PAR859A,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,PAR8-59A / 8.0 ft,PAR859A80FT,8,2.44,40.8,Comsearch's Frequency Coordination Database
 ANDREW,PAR8 59A RF,PAR859ARF,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8-59A RF,PAR859ARF,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR8-59A RF,PAR859ARF,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,par8-59a rf,PAR859ARF,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR8-59A RF,PAR859ARF,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8-59B,PAR859B,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR8-59B,PAR859B,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR8-59B RF,PAR859BRF,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR8-59-P7A,PAR859P7A,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR8-59 (V) LF,PAR859VLF,8,2.44,40.8,Using PAR8-59
 ANDREW,PAR8-59W,PAR859W,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR8-59W,PAR859W,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8-59WA,PAR859WA,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1269,12 +1694,12 @@ ANDREW,PAR8-59W LF,PAR859WLF,8,2.44,41,https://www.digchip.com/datasheets/parts/
 COMMSCOPE,PAR8-59W LF,PAR859WLF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8-59W RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8-59W RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR8-59W RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR8-59W RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW CORPORATION,PAR8-59W RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,par8-59w rf,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PAR8-59-W RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8-59W-RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW CORPORATION,PAR8-59W RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR8-59W RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR8-59W RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PAR8-59-W RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR8-59W-RF,PAR859WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR8-59W RF (V-POL ONLY),PAR859WRFVPOLONLY,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8-59W RP,PAR859WRP,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1286,8 +1711,15 @@ COMMSCOPE,PAR859W (V)RF,PAR859WVRF,8,2.44,41,https://www.digchip.com/datasheets/
 COMMSCOPE,PAR8-59W (V)RF,PAR859WVRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR8-59W (V)RF,PAR859WVRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PAR8-59W V(RF),PAR859WVRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corp,PAR8&6,PAR86,8,2.44,,"This base model is PAR8&6, looks like they meant to do the two antenna models for diversity purposes. "
+Commscope,PAR8&6,PAR86,8,2.44,,"This base model is PAR8&6, looks like they meant to do the two antenna models for diversity purposes. "
 ANDREW,PAR8-65,PAR865,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR8-65,PAR865,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+Andrew Corp,PAR8&6-59a,PAR8659A,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corp,PAR8&6-59A RF,PAR8659ARF,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corp,PAR8&6-59W,PAR8659W,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corp,PAR8&6-59WA RF,PAR8659WARF,8,2.44,41,Used PAR8-59WA RF. 
+Andrew Corp,PAR8&6-59W RF,PAR8659WRF,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8 65A,PAR865A,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65A,PAR865A,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 CABLEWAVE SYSTEMS,PAR8-65A,PAR865A,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
@@ -1298,9 +1730,9 @@ ANDREW,PAR8-65A LF,PAR865ALF,8,2.44,41.3,https://www.digchip.com/datasheets/part
 COMMSCOPE,PAR8-65A LF,PAR865ALF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8 65A RF,PAR865ARF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65A RF,PAR865ARF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR8-65A RF,PAR865ARF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR8-65A RF,PAR865ARF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65A-RF,PAR865ARF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR8-65A RF,PAR865ARF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR8-65A RF,PAR865ARF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65 B,PAR865B,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65B,PAR865B,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR8-65B,PAR865B,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
@@ -1308,31 +1740,36 @@ ANDREW,PAR8-65 B LF,PAR865BLF,8,2.44,41.3,https://www.digchip.com/datasheets/par
 ANDREW,PAR8-65B LF,PAR865BLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65B LF,PAR865BLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65B LF,PAR865BLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR8-65B LF,PAR865BLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 Andrew Corporation,PAR8-65B LF,PAR865BLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR8-65B LF,PAR865BLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65B R,PAR865BR,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65B-R,PAR865BR,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8 65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8 -65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR8-65 B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR8-65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR8-65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-Andrew Corporation,PAR8-65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65B rf,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PAR8-65B- RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-ANDREW,PAR-8-65B RF,PAR865BRF,6,1.83,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+ANDREW,PAR-8-65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65B RF`,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65B-RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+Andrew Corporation,PAR8-65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR8-65 B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR8-65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR8-65B RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR8-65B- RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR8-65B-RF,PAR865BRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65D,PAR865D,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-65LF,PAR865LF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR8-65-PXA,PAR865PXA,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PAR8-65-PXA (RF),PAR865PXARF,8,2.44,41.3,Comsearch's Frequency Coordination Database
 ANDREW,PAR8-65 RF,PAR865RF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PAR8-65 RF,PAR865RF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PAR8-69W RF,PAR869WRF,8,2.44,,Indeterminate. Band designator 69 has multiple options
+Andrew Corp,PAR8&8-59,PAR8859,8,2.44,40.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corp,PAR8&8-59W,PAR8859W,8,2.44,41,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PAR8X-59W,PAR8X59W,8,2.44,40.7,Typo should be PARX8-59W
+COMMSCOPE,PARA-59W (V) LF,PARA59WVLF,,,,Indeterminate. 
+Andrew Corp,PARA65B-RF,PARA65BRF,,,,Indeterminate. 
 ANDREW,PARA6-65A,PARA665A,6,1.83,,Indeterminate.  Prefix could be PAR6 or PARX6. 
 ANDREW,PARX10-59,PARX1059,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX10-59,PARX1059,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1347,39 +1784,45 @@ ANDREW,PARX10-59W RF,PARX1059WRF,10,3.05,43.3,https://www.digchip.com/datasheets
 ANDREW,PARX10-65,PARX1065,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PARX10-65,PARX1065,10,3.05,43.6,Comsearch's Frequency Coordination Database
 ANDREW,PARX10-65 RF,PARX1065RF,10,3.05,43.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+ANDREW CORPORATION,PARX10-95WA,PARX1095WA,10,3.05,43.3,"Typo, probably meant to be PARX1059WA"
+RFS,PARX10-W59,PARX10W59,10,3.05,43.3,Comsearch Frequency Coordination Database for PARX10-59W
 COMMSCOPE,PARX12-59,PARX1259,12,3.66,44.7,Comsearch's Frequency Coordination Database
 ANDREW,PARX12-59-P7M,PARX1259P7M,12,3.66,44.7,https://objects.eanixter.com/PD355695.PDF
 COMMSCOPE,PARX12-65,PARX1265,12,3.66,45.5,Comsearch's Frequency Coordination Database
+ANDREW CORPORATION,PARX-59A,PARX59A,,,,Indeterminate. 
+Andrew Corp,PARX-59W,PARX59W,,,,Indeterminate. 
+Comscope,PARX-59WA,PARX59WA,,,,Indeterminate. 
+Andrew,PARX-65,PARX65,,,,Indeterminate. 
 COMMSCOPE,PARX6-51A,PARX651A,6,1.83,,Indeterminate. Band designator 51 unknown. 
 ANDREW,PARX6-59,PARX659,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PARX6-59,PARX659,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARx6-59,PARX659,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PARX6-59,PARX659,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX6?59A,PARX659A,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,PARX6-59A,PARX659A,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,PARX6-59a,PARX659A,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX6?59A,PARX659A,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX659A,PARX659A,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW,PARX6-59A,PARX659A,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX6-59A,PARX659A,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW,PARX6-59a,PARX659A,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX6-59-A,PARX659A,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 RFS,PARX6-59-PXA,PARX659PXA,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX6-59-PXA/A,PARX659PXAA,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX6-59-PXA/A,PARX659PXAA,6,1.83,37.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX6-59W,PARX659W,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PARX6-59W,PARX659W,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX6-59w,PARX659W,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PARX6-59W,PARX659W,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARx6-59W,PARX659W,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX6-59W A,PARX659WA,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PARX659WA,PARX659WA,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX6-59WA,PARX659WA,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PARX659WA,PARX659WA,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX6-59WA,PARX659WA,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PARX659WB,PARX659WB,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX6-59WB,PARX659WB,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PARX659WB,PARX659WB,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX6-59WB,PARX659WB,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX6-59W RF,PARX659WRF,6,1.83,38.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX6-65,PARX665,6,1.83,38.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PARX6-65,PARX665,6,1.83,38.4,Comsearch's Frequency Coordination Database
 ANDREW,parx6-65,PARX665,6,1.83,38.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,Parx6-65,PARX665,6,1.83,38.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PARX6-65,PARX665,6,1.83,38.4,Comsearch's Frequency Coordination Database
 COMMSCOPE,PARX6-65A,PARX665A,6,1.83,38.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,PARX6-95A,PARX695A,6,1.83,38.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PARX8,PARX8,8,2.44,,No band indicated in model so cannot determine gain. 
@@ -1392,19 +1835,22 @@ ANDREW,PARX8?59W,PARX859W,8,2.44,40.7,https://www.digchip.com/datasheets/parts/d
 ANDREW,PARX859W,PARX859W,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX8-59W,PARX859W,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX8-59W,PARX859W,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,PARX8-59WA,PARX859WA,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX8 59WA,PARX859WA,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX8-59 WA,PARX859WA,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX859WA,PARX859WA,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW,PARX8-59WA,PARX859WA,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX8-59WA,PARX859WA,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PARX8-59WR,PARX859WR,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX8-59W RF,PARX859WRF,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX8-59W-RF,PARX859WRF,8,2.44,40.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PARX8-65,PARX865,8,2.44,41.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,PARX8-65,PARX865,8,2.44,41.2,Comsearch's Frequency Coordination Database
 ANDREW,Parx8-65,PARX865,8,2.44,41.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,PARX8-65,PARX865,8,2.44,41.2,Comsearch's Frequency Coordination Database
 Andrew Corp,PARX8-65-PXA,PARX865PXA,8,2.44,41.2,https://objects.eanixter.com/PD355711.PDF
+Andrew Corporation,PARX9-59,PARX959,,,,Indeterminate. 
+COMMSCOPE,PARXL-59A,PARXL59A,,,,Indeterminate. 
 CABLEWAVE SYSTEMS,PAS8-59,PAS859,8,2.44,41.3,Typo should be PAD859. Using that gain.
+RFS,PASX8-U57A,PASX8U57A,,,,Indeterminate
 RFS,PAX10-59A,PAX1059A,10,3.05,43.2,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAX10-59A S94100,PAX1059AS94100,10,3.05,43.2,Comsearch's Frequency Coordination Database
 RFS,PAX10-65A,PAX1065A,10,3.05,43.9,Comsearch's Frequency Coordination Database
@@ -1421,16 +1867,22 @@ RFS,PAX8-65,PAX865,8,2.44,42.2,Comsearch's Frequency Coordination Database
 RFS,PAX8-65A,PAX865A,8,2.44,42.2,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,PAX8-65B,PAX865B,8,2.44,42.2,Comsearch's Frequency Coordination Database
 RFS,PAX8-W59A,PAX8W59A,8,2.44,41.7,Comsearch's Frequency Coordination Database
+Andrew Corporation,PD10-65D,PD1065D,10,3.05,43.9,Used PDV10-65D from https://www.datasheets360.com/pdf/-4500121692955819986
 RFS,PD6-W59B,PD6W59B,6,1.83,39.1,Typo should be PAD6W59B. Using that gain
 CABLEWAVE SYSTEMS,PD8-59AC,PD859AC,8,2.44,41.3,Typo should be PAD859AC. Using that gain
 ANDREW,PDH8-65 MAIN,PDH865MAIN,8,2.44,42.4,https://www.datasheets360.com/pdf/-4500121692955819986
 ANDREW,PDH8-65 main,PDH865MAIN,8,2.44,42.4,https://www.datasheets360.com/pdf/-4500121692955819986
 RFS,PDX8-W57A,PDX8W57A,8,2.44,41.4,Should be PADX8W57A. Gain from Comsearch frequency coordination database. 
-Commscope/Andrew,PL1057W,PL1057W,10,3.05,42.9,https://objects.eanixter.com/PD355726.PDF
+Andrew Corporation,PF8-65F,PF865F,8,2.44,,Indeterminate. 
+ANDREW CORPORATION,PH10-59E,PH1059E,10,3.05,,Not sure of performance - P10 or HP10?
+ANDREW CORPORATION,PH8-65,PH865,8,2.44,,Indeterminate. 
+SAF TEHNIKA,PhG2_L6_137M30S_VHP,PHG2L6137M30SVHP,,,,Radio - Indeterminate. 
+SAF Tehnika,PHG2_L6_452M60S_VHP ACM,PHG2L6452M60SVHPACM,,,,Radio - Indeterminate. 
 ANDREW,PL10-57W,PL1057W,10,3.05,42.9,https://objects.eanixter.com/PD355726.PDF
-Commscope/Andrew,PL1059,PL1059,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,PL1057W,PL1057W,10,3.05,42.9,https://objects.eanixter.com/PD355726.PDF
 ANDREW,PL10-59,PL1059,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL10-59,PL1059,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,PL1059,PL1059,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Andrew Corporation,PL10-59C,PL1059C,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL10-59D,PL1059D,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL10-59D,PL1059D,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1438,13 +1890,13 @@ ANDREW,PL10-59E,PL1059E,10,3.05,43.3,https://www.digchip.com/datasheets/parts/da
 COMMSCOPE,PL10-59E,PL1059E,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL10-59F,PL1059F,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL10-59W,PL1059W,10,3.05,43.6,https://www.jmu.edu/wmra-eng/archive/AndrewCatalog38.pdf
-COMMSCOPE,PL10-59W,PL1059W,10,3.05,43.6,https://www.jmu.edu/wmra-eng/archive/AndrewCatalog38.pdf
 ANDREW,pl10-59w,PL1059W,10,3.05,43.6,https://www.jmu.edu/wmra-eng/archive/AndrewCatalog38.pdf
+COMMSCOPE,PL10-59W,PL1059W,10,3.05,43.6,https://www.jmu.edu/wmra-eng/archive/AndrewCatalog38.pdf
 ANDREW,PL10-59WA,PL1059WA,10,3.05,43.6,https://www.jmu.edu/wmra-eng/archive/AndrewCatalog38.pdf
 COMMSCOPE,PL10-59WA,PL1059WA,10,3.05,43.6,https://www.jmu.edu/wmra-eng/archive/AndrewCatalog38.pdf
-Commscope/Andrew,PL1065,PL1065,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL10-65,PL1065,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 COMMSCOPE,PL10-65,PL1065,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
+Commscope/Andrew,PL1065,PL1065,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 RFS,PL10-65A,PL1065A,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL10-65C,PL1065C,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL10-65D,PL1065D,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
@@ -1452,15 +1904,16 @@ COMMSCOPE,PL10-65D,PL1065D,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url
 COMMSCOPE,Pl10-65D,PL1065D,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL10-65E,PL1065E,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 COMMSCOPE,PL10-65E,PL1065E,10,3.05,43.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
-Commscope/Andrew,PL1259,PL1259,12,3.66,45,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,PL10-65F,PL1065F,10,3.05,43.9,Assumed same as PL10-65E
 ANDREW,PL12-59,PL1259,12,3.66,45,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,PL1259,PL1259,12,3.66,45,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL12-59D,PL1259D,12,3.66,45,Comsearch's Frequency Coordination Database
 ANDREW,PL12-59E,PL1259E,12,3.66,45,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL12-59E,PL1259E,12,3.66,45,Comsearch's Frequency Coordination Database
 COMMSCOPE,PL12-59F,PL1259F,12,3.66,45,Comsearch's Frequency Coordination Database
 ANDREW,PL12-59WB,PL1259WB,12,3.66,45,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope/Andrew,PL1265,PL1265,12,3.66,45.6,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL12-65,PL1265,12,3.66,45.6,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
+Commscope/Andrew,PL1265,PL1265,12,3.66,45.6,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL12-65D,PL1265D,12,3.66,45.6,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 COMMSCOPE,PL12-65D,PL1265D,12,3.66,45.6,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL12-65E,PL1265E,12,3.66,45.6,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
@@ -1472,27 +1925,29 @@ Commscope/Andrew,PL1565,PL1565,15,4.57,47.4,https://www.datasheet.live/pdfviewer
 ANDREW,PL15-65D,PL1565D,15,4.57,47.4,https://objects.eanixter.com/PD400419.PDF
 ANDREW,PL4-107E,PL4107E,,,,Model does not belong in this band.
 COMMSCOPE,PL4-65D,PL465D,4,1.22,36.3,Comsearch's Frequency Coordination Database
+Andrew Corp,PL5-59F,PL559F,,,,Diameter indeterminate
 ANDREW,PL*-57W,PL57W,8,2.44,41.2,https://objects.eanixter.com/PD355887.PDF
+Andrew Corp,PL-59D,PL59D,,,,Indeterminate. 
 ANDREW,PL6-107E,PL6107E,,,,Model does not belong in this band.
-Commscope/Andrew,PL657W,PL657W,6,1.83,38.5,https://objects.eanixter.com/PD355844.PDF
 ANDREW,PL6-57W,PL657W,6,1.83,38.5,https://objects.eanixter.com/PD355844.PDF
 COMMSCOPE,PL6-57W,PL657W,6,1.83,38.5,Comsearch's Frequency Coordination Database
+Commscope/Andrew,PL657W,PL657W,6,1.83,38.5,https://objects.eanixter.com/PD355844.PDF
 ANDREW,PL6-57WA,PL657WA,6,1.83,38.5,https://objects.eanixter.com/PD355844.PDF
 COMMSCOPE,PL6-57WA,PL657WA,6,1.83,38.5,Comsearch's Frequency Coordination Database
 COMMSCOPE,PL6-58WB,PL658WB,6,1.83,39.5,Typo should be PL659WB. Using that gain
-Commscope/Andrew,PL659,PL659,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL6-59,PL659,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL6-59,PL659,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,PL659,PL659,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL6-59A,PL659A,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL6-59C,PL659C,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL6-59C,PL659C,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope,PL659D,PL659D,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL6-59D,PL659D,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,PL659D,PL659D,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL6-59D,PL659D,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL6-59E,PL659E,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL6-59E,PL659E,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope,PL659F,PL659F,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL6-59F,PL659F,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,PL659F,PL659F,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL6-59F,PL659F,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL6-59 PXA,PL659PXA,6,1.83,39.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL6-59W,PL659W,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1503,9 +1958,9 @@ ANDREW,PL6-59WC,PL659WC,6,1.83,39.5,https://www.digchip.com/datasheets/parts/dat
 COMMSCOPE,PL6-59WC,PL659WC,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL6-59W-PXA,PL659WPXA,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL65-F,PL65F,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
-Commscope/Andrew,PL665,PL665,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL6-65,PL665,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 COMMSCOPE,PL6-65,PL665,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
+Commscope/Andrew,PL665,PL665,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL6-65C,PL665C,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL6-65C (FCC A95100),PL665CFCCA95100,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL6 65D,PL665D,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
@@ -1519,22 +1974,23 @@ ANDREW,PL6-65F,PL665F,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https
 COMMSCOPE,PL6-65F,PL665F,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL6-65G,PL665G,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 COMMSCOPE,PL6-65G,PL665G,6,1.83,39.9,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
+Andrew Corporation,PL8,PL8,8,2.44,,Indeterminate. 
 ANDREW,PL8-186C V,PL8186CV,8,2.44,42,Comsearch's Frequency Coordination Database
 COMMSCOPE,PL8-186C V,PL8186CV,8,2.44,42,Comsearch's Frequency Coordination Database
 Andrew,PL8-56D,PL856D,8,2.44,42.3,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 ANDREW,PL857W,PL857W,8,2.44,41.2,https://objects.eanixter.com/PD355886.PDF
-Commscope/Andrew,PL857W,PL857W,8,2.44,41.2,https://objects.eanixter.com/PD355886.PDF
 ANDREW,PL8-57W,PL857W,8,2.44,41.2,https://objects.eanixter.com/PD355886.PDF
 COMMSCOPE,PL8-57W,PL857W,8,2.44,41.2,Comsearch's Frequency Coordination Database
+Commscope/Andrew,PL857W,PL857W,8,2.44,41.2,https://objects.eanixter.com/PD355886.PDF
 ANDREW,PL8 59,PL859,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope/Andrew,PL859,PL859,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL8-59,PL859,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL8-59,PL859,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,PL859,PL859,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL8-59A,PL859A,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL8-59C,PL859C,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL8-59C,PL859C,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope,PL859D,PL859D,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL8-59D,PL859D,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,PL859D,PL859D,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL8-59D,PL859D,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL8-59E,PL859E,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL8-59E,PL859E,8,2.44,41.6,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1545,32 +2001,53 @@ ANDREW,PL8 59W,PL859W,8,2.44,42,https://www.digchip.com/datasheets/parts/datashe
 ANDREW,PL8-59W,PL859W,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PL8-59W,PL859W,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL8-59WB,PL859WB,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PL8-59WB,PL859WB,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL8-59wb,PL859WB,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PL8-59WB,PL859WB,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PL8-59w rf,PL859WRF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope/Andrew,PL865,PL865,8,2.44,42.4,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL8-65,PL865,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 COMMSCOPE,PL8-65,PL865,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
+Commscope/Andrew,PL865,PL865,8,2.44,42.4,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PL8-65C,PL865C,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 COMMSCOPE,PL8-65C,PL865C,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 ANDREW,PL8 - 65D,PL865D,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 ANDREW,PL8 65D,PL865D,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 ANDREW,PL8-65D,PL865D,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
-COMMSCOPE,PL8-65D,PL865D,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 ANDREW,PL8-65d,PL865D,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
-COMMSCOPE,Pl8-65D,PL865D,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 ANDREW,PL8-65-D,PL865D,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
-COMMSCOPE,PL8-65.F,PL865F,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
+COMMSCOPE,PL8-65D,PL865D,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
+COMMSCOPE,Pl8-65D,PL865D,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 ANDREW,PL8-65F,PL865F,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
+COMMSCOPE,PL8-65.F,PL865F,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 COMMSCOPE,PL8-65F,PL865F,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 COMMSCOPE,Pl8-65F,PL865F,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 ANDREW,PL8-65G,PL865G,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 ANDREW,PL8-65WB,PL865WB,8,2.44,42.4,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FPL8-65D.pdf
 ANDREW,PL8-69F,PL869F,8,2.44,,Indeterminate. Band designator 69 has multiple options
+ANDREW,PLD-65D,PLD65D,,,,Indeterminate. 
 ANDREW,PLX8-59D,PLX859D,8,2.44,41.3,Typo should be PXL859D. Using that gain. 
 ANDREW,PLX8-65D,PLX865D,8,2.44,42,Typo should be PXL865D. Using that gain. 
 RFS,PPAD6-65B,PPAD665B,6,1.83,39.6,http://www.dadehnama.ir/uploads/4_313508659575390274.pdf
+ANDREW CORPORATION,PR6 65A,PR665A,6,1.83,38.8,Assumed to be PAR6-65A
+PRODELIN INC,PRODELIN INC,PRODELININC,,,,Indeterminate. 
+MICROWAVE NETWORKS INC,PROTEUS MX IDU HP,PROTEUSMXIDUHP,,,,Indeterminate. 
 RFS,PS8-65A,PS865A,8,2.44,42.4,Typo should be PA865A. Using that gain
+Andrew Corporation,PSR6-59WA RF,PSR659WARF,6,1.83,38.7,Used PAR6-59WA RF.
+Andrew,PSR8-65B,PSR865B,8,2.44,41.3,Assumed to be PAR8-65B
+MARK ANTENNA,PT-65A96,PT65A96,8,2.44,39.5,Comsearch's Frequency Coordination Database
+Cambium Networks,ptp6850cv2acm,PTP6850CV2ACM,,,,Radio - Indeterminate. 
+"Cambium Networks, LTD",PTP-820G Split,PTP820GSPLIT,,,,Radio - Indeterminate. 
+Cambium Networks,PTP 820SP 6' (HP6-6),PTP820SP6HP66,,,,Radio - Indeterminate. 
+Cambium Networks,PTPL6800,PTPL6800,,,,Radio - Indeterminate. 
+"Cambium Networks, LTD",PTPL6800-I IRFU-HP,PTPL6800IIRFUHP,,,,Radio - Indeterminate. 
+Cambium,PTP-L6800-IRFU,PTPL6800IRFU,,,,Radio - Indeterminate. 
+"Cambium Networks, LTD",PTPL6820C-V2,PTPL6820CV2,,,,Radio - Indeterminate. 
+Cambium Networks,ptpl6820Cv2acm,PTPL6820CV2ACM,,,,Radio - Indeterminate. 
+Cambium Networks,PTPL6820S,PTPL6820S,,,,Radio - Indeterminate. 
+CommScope,PTPL6820S,PTPL6820S,,,,Radio - Indeterminate. 
+Cambium Networks,PTPU6850C,PTPU6850C,,,,Radio - Indeterminate. 
+"Cambium Networks, LTD",PTPU6850C-V3,PTPU6850CV3,,,,Radio - Indeterminate. 
+LigoWave,PTPX-620S-ANT-3,PTPX620SANT3,3,0.91,33.3,Comsearch's Frequency Coordination Database
+RFS,PWHQ413WAX10-65A,PWHQ413WAX1065A,,,,Indeterminate. 
 COMMSCOPE,PX10-59C,PX1059C,10,3.05,43.1,Comsearch's Frequency Coordination Database
 ANDREW,PX10-59D,PX1059D,10,3.05,42.9,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 ANDREW,PX6-59,PX659,6,1.83,38.6,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
@@ -1579,31 +2056,33 @@ ANDREW,PX6-59C,PX659C,6,1.83,38.6,https://worldradiohistory.com/Archive-Catalogs
 ANDREW,PX6-59E,PX659E,6,1.83,38.6,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 Andrew Corporation,PX8-59,PX859,8,2.44,41,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 COMMSCOPE,PX8-59C,PX859C,8,2.44,41.2,Comsearch's Frequency Coordination Database
-ANDREW,PX8-59D,PX859D,8,2.44,41,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
+ANDREW,PX8-59D,PX859D,8,2.44,41.3,Comsearch's Frequency Coordination Database
 ANDREW,PX8-65D,PX865D,8,2.44,41.9,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 COMMSCOPE,PX8-65D,PX865D,8,2.44,41.9,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-26-1969.pdf
 RFS,PXA8-65,PXA865,8,2.44,42.2,Typo should be PAX865. Using that Gain.
-Commscope/Andrew,PXL1059,PXL1059,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+"Trango Networks, LLC.",PXG2-NITRO 6G 60M 4096Q 5,PXG2NITRO6G60M4096Q5,,,,Radio - Indeterminate. 
+"Trango Networks, LLC",PXG2-NITRO 6GHz,PXG2NITRO6GHZ,,,,Radio - Indeterminate. 
 COMMSCOPE,PXL10-59,PXL1059,10,3.05,43.1,Comsearch's Frequency Coordination Database
+Commscope/Andrew,PXL1059,PXL1059,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Andrew Corporation,PXL10-59C,PXL1059C,10,3.05,43.1,Comsearch's Frequency Coordination Database
 ANDREW,PXL10-59D,PXL1059D,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PXL10-59D,PXL1059D,10,3.05,43.1,Comsearch's Frequency Coordination Database
-Commscope/Andrew,PXL1065,PXL1065,10,3.05,44,https://www.launch3telecom.com/commscopeandrew/pxl1065d7a.html
 ANDREW,PXL10-65,PXL1065,10,3.05,44,https://www.launch3telecom.com/commscopeandrew/pxl1065d7a.html
 COMMSCOPE,PXL10-65,PXL1065,10,3.05,44,Comsearch's Frequency Coordination Database
+Commscope/Andrew,PXL1065,PXL1065,10,3.05,44,https://www.launch3telecom.com/commscopeandrew/pxl1065d7a.html
 ANDREW,PXL10-65D,PXL1065D,10,3.05,44,https://www.launch3telecom.com/commscopeandrew/pxl1065d7a.html
 COMMSCOPE,PXL10-65D,PXL1065D,10,3.05,44,Comsearch's Frequency Coordination Database
-Commscope/Andrew,PXL1259,PXL1259,12,3.66,45,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,PXL1259,PXL1259,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PXL12-59F,PXL1259F,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,PXL12-59F,PXL1259F,12,3.66,44.8,Comsearch's Frequency Coordination Database
 ANDREW,PXl12-59F,PXL1259F,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PXL12-59F,PXL1259F,12,3.66,44.8,Comsearch's Frequency Coordination Database
 Commscope/Andrew,PXL1265,PXL1265,12,3.66,45.4,https://www.launch3telecom.com/commscopeandrew/pxl1265.html
 ANDREW,PXL12-65E,PXL1265E,12,3.66,45.4,https://www.launch3telecom.com/commscopeandrew/pxl1265.html
 COMMSCOPE,PXL12-65E,PXL1265E,12,3.66,45.4,Comsearch's Frequency Coordination Database
 ANDREW,PXL1O-59D,PXL1O59D,10,3.05,43.1,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope/Andrew,PXL659,PXL659,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PXL6-59,PXL659,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PXL6-59,PXL659,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,PXL659,PXL659,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PXL6-59D,PXL659D,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PXL6-59E,PXL659E,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PXL6-59E,PXL659E,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1612,27 +2091,46 @@ COMMSCOPE,PXL6-59F,PXL659F,6,1.83,38.7,https://www.digchip.com/datasheets/parts/
 Commscope/Andrew,PXL665,PXL665,6,1.83,39.4,https://www.datasheet.live/pdfviewer?url=https%3A%2F%2Fpdf.datasheet.live%2Fdatasheets-1%2Fandrew%2FPL6-65.pdf
 ANDREW,PXL6-65D,PXL665D,6,1.83,39.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,PXL6-65D,PXL665D,6,1.83,39.4,Comsearch's Frequency Coordination Database
-Commscope/Andrew,PXL859,PXL859,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,PXL8-59,PXL859,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,PXL859,PXL859,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,PXL8-59C,PXL859C,8,2.44,41.3,Comsearch's Frequency Coordination Database
-COMMSCOPE,PXL859D,PXL859D,8,2.44,41.3,Comsearch's Frequency Coordination Database
 ANDREW,PXL8-59D,PXL859D,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,PXL859D,PXL859D,8,2.44,41.3,Comsearch's Frequency Coordination Database
 COMMSCOPE,PXL8-59D,PXL859D,8,2.44,41.3,Comsearch's Frequency Coordination Database
 ANDREW,PXL8-59 RF,PXL859RF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope/Andrew,PXL865,PXL865,8,2.44,42,https://objects.eanixter.com/PD356081.PDF
 ANDREW,PXL8-65,PXL865,8,2.44,42,https://objects.eanixter.com/PD356081.PDF
+Commscope/Andrew,PXL865,PXL865,8,2.44,42,https://objects.eanixter.com/PD356081.PDF
 RFS,PXL8-65,PXL865,8,2.44,42,Comsearch's Frequency Coordination Database
 ANDREW,PXL8-65C,PXL865C,8,2.44,42,https://objects.eanixter.com/PD356081.PDF
 ANDREW,PXL8-65D,PXL865D,8,2.44,42,https://objects.eanixter.com/PD356081.PDF
 COMMSCOPE,PXL8-65D,PXL865D,8,2.44,42,Comsearch's Frequency Coordination Database
+Cambium Networks,pypl6820cv2ACM,PYPL6820CV2ACM,,,,Radio - Indeterminate. 
+Gabriel Electronics,R16P-2J23,R16P2J23,16,4.88,47,Assumed to be RF16P-2J23
 RFS,RAD6-65A,RAD665A,6,1.83,39.6,Typo should be PAD665A. Using that gain. 
+PAL8-59A,RADIO FREQUENCY SYSTEMS,RADIOFREQUENCYSYSTEMS,,,,Indeterminate. 
+"RADIO WAVES, INC",RADIO WAVES INC,RADIOWAVESINC,,,,Indeterminate. 
+"RADIO WAVES, INC.",RADIO WAVES INC.,RADIOWAVESINC,,,,Indeterminate. 
+Andrew Corporation,RARX6-59,RARX659,6,1.83,37.9,Assumed to be PARX6-59
 GABRIEL,RF10P-2J23,RF10P2J23,10,3.05,43.5,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,RF16P-2J23,RF16P2J23,16,4.88,47,Comsearch's Frequency Coordination Database
+"Repeater Technologies,Inc",RF-6000E,RF6000E,,,,Indeterminate. 
 GABRIEL ELECTRONICS,RF8C-J45,RF8CJ45,8,2.44,42,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,RFB10P-59,RFB10P59,10,3.05,43.2,Comsearch's Frequency Coordination Database
+"RF Communications, LLC",RFCM-0640UH18WD,RFCM0640UH18WD,6,1.83,39.4,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,RFD8-264BSE,RFD8264BSE,8,2.44,41.7,Comsearch's Frequency Coordination Database
+RF Engineering and Energy,RFMA-0640UH1 8WS,RFMA0640UH18WS,6,1.83,39.4,Comsearch's Frequency Coordination Database
+RF ENGINEERING AND ENERGY,RFMA-0640UH1.8WSXX,RFMA0640UH18WSXX,6,1.83,39.4,Comsearch's Frequency Coordination Database
 <RF Engineering & Energy R>,<RFMA-0736UH1.2WS>,RFMA0736UH12WS,4,1.22,35.6,https://rfeq.com/wp-content/uploads/2018/10/RFMA-0736UH1.2WSxx-new.pdf
 RF ENGINEERING AND ENERGY,RFMA-0736UH1.2WS,RFMA0736UH12WS,4,1.22,35.6,https://rfeq.com/wp-content/uploads/2018/10/RFMA-0736UH1.2WSxx-new.pdf
+WNEV787,RFS,RFS,,,,Indeterminate. 
+PAD6-65AC,RF SYSTEMS,RFSYSTEMS,,,,Indeterminate. 
+CABLE AML,SALINAS-HP-6L 30M,SALINASHP6L30M,,,,Radio - Indeterminate. 
+RFS,SB2-105A,SB2105A,2,0.61,,10 GHz Antenna
 RFS,SB4-W60,SB4W60,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SB4-W60EC
 RFS,SB4-W60A,SB4W60A,4,1.22,34.8,https://www.rfsworld.com/pim/product/html/SB4-W60EC
 RFS,SB4-W60C,SB4W60C,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SB4-W60EC
+RFS,SB4-W60C,SB4W60C,4,1.22,35.7,Comsearch's Frequency Coordination Database
+RFS,SB4-W60CC,SB4W60CC,4,1.22,35.7,Comsearch's Frequency Coordination Database
 RFS,SB4-W60CMPT,SB4W60CMPT,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SB4-W60EC
 RFS,Sb4-W60CMPT,SB4W60CMPT,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SB4-W60EC
 RFS,SB4-W60D,SB4W60D,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SB4-W60EC
@@ -1646,8 +2144,8 @@ RFS,SB6-W60C,SB6W60C,6,1.83,39.4,https://www.rfsworld.com/pim/product/html/SB6-W
 RFS,SB6-W60CMPT,SB6W60CMPT,6,1.83,39.4,https://www.rfsworld.com/pim/product/html/SB6-W60DC2
 RFS,SB6-W60D,SB6W60D,6,1.83,39.4,https://www.rfsworld.com/pim/product/html/SB6-W60DC2
 RFS,SB6-W60DMPT,SB6W60DMPT,6,1.83,39.4,https://www.rfsworld.com/pim/product/html/SB6-W60DC2
-RFS,SBX4?W60A,SBX4W60A,4,1.22,34.8,https://www.rfsworld.com/pim/product/html/SBX4-W60EC
 COMMSCOPE,SBX4-W60A,SBX4W60A,4,1.22,34.8,Comsearch's Frequency Coordination Database
+RFS,SBX4?W60A,SBX4W60A,4,1.22,34.8,https://www.rfsworld.com/pim/product/html/SBX4-W60EC
 RFS,SBX4-W60A,SBX4W60A,4,1.22,34.8,https://www.rfsworld.com/pim/product/html/SBX4-W60EC
 RFS,SBX4?¡W60C,SBX4W60C,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SBX4-W60EC
 RFS,SBX4W60C,SBX4W60C,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SBX4-W60EC
@@ -1655,6 +2153,7 @@ RFS,SBX4-W60C,SBX4W60C,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SBX
 RFS,SBX4-W60CMPT,SBX4W60CMPT,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SBX4-W60EC
 RFS,SBX4-W60D,SBX4W60D,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SBX4-W60EC
 RFS,SBX4-W60DIPN,SBX4W60DIPN,4,1.22,35.7,https://www.rfsworld.com/pim/product/html/SBX4-W60EC
+RFS,SBX4-W60E,SBX4W60E,4,1.22,35.7,Comsearch's Frequency Coordination Database
 RFS,SBX6-W30C,SBX6W30C,6,1.83,,Indeterminate. Band designator 30 unknown
 RFS,SBX6-W60A,SBX6W60A,6,1.83,39.4,https://www.rfsworld.com/pim/product/html/SBX6-W60DC2
 RFS,SBX6-W60B,SBX6W60B,6,1.83,39.4,https://www.rfsworld.com/pim/product/html/SBX6-W60DC2
@@ -1665,15 +2164,19 @@ RFS,SBX6-W60CC,SBX6W60CC,6,1.83,39.4,https://www.rfsworld.com/pim/product/html/S
 RFS,SBX6-W60CIPN,SBX6W60CIPN,6,1.83,39.4,https://www.rfsworld.com/pim/product/html/SBX6-W60DC2
 RFS,SBX6-W60CMPT,SBX6W60CMPT,6,1.83,39.4,https://www.rfsworld.com/pim/product/html/SBX6-W60DC2
 RFS,SBX6-W60D,SBX6W60D,6,1.83,39.4,https://www.rfsworld.com/pim/product/html/SBX6-W60DC2
+RFS,SBX-W60C,SBXW60C,,,,Diameter indeterminate
 RFS,SC3-W60,SC3W60,3,0.91,33.2,https://www.rfsworld.com/pim/product/html/SC3-W60BC
 RFS,SC3W60A,SC3W60A,3,0.91,33.2,https://www.rfsworld.com/pim/product/html/SC3-W60BC
 RFS,SC3-W60A,SC3W60A,3,0.91,33.2,https://www.rfsworld.com/pim/product/html/SC3-W60BC
 RFS,SC3-W60A SC3-,SC3W60ASC3,3,0.91,33.2,https://www.rfsworld.com/pim/product/html/SC3-W60BC
+RFS,SC3-W60B,SC3W60B,3,0.91,33.2,Comsearch's Frequency Coordination Database
+RFS,SCX3-W100A,SCX3W100A,3,0.91,,Indeterminate. Wrong Band
 RFS,SCX3-W60A,SCX3W60A,3,0.91,33.2,https://www.rfsworld.com/pim/product/html/SCX3-W60BC
 RFS,SCX3-W60AMPT,SCX3W60AMPT,3,0.91,33.2,https://www.rfsworld.com/pim/product/html/SCX3-W60BC
 RFS,SCX3-W60W,SCX3W60W,3,0.91,33.2,https://www.rfsworld.com/pim/product/html/SCX3-W60BC
 COMMSCOPE,SEUHX6-59 RF,SEUHX659RF,6,1.83,38.8,Comsearch's Frequency Coordination Database
-Commscope,SHP3-6W,SHP36W,3,1.22,33.6,https://www.commscope.com/globalassets/digizuite/696934-p360-shp3-6w-4wh-b-external.pdf
+Commscope,SHP3-6W,SHP36W,3,0.91,33.6,https://www.commscope.com/globalassets/digizuite/696934-p360-shp3-6w-4wh-b-external.pdf
+Commscope,SHP3-6W/BUS,SHP36WBUS,3,0.91,33.6,Comsearch's Frequency Coordination Database
 RADIO WAVES,SHP6-59,SHP659,6,1.83,39,https://www.radiowaves.com/getmedia/22d052e7-9370-4f2b-81b5-0dafc7c72849/SHP6-5.9.aspx
 RADIO WAVES,SHP6-6,SHP66,6,1.83,39.3,https://www.radiowaves.com/getmedia/f938b911-2fb8-4c71-8b06-53a59d88df1f/SHP6-6.aspx
 RADIO WAVES,SHPD6-5.9,SHPD659,6,1.83,38.8,https://www.radiowaves.com/getmedia/12291e54-5884-4572-a349-1f5c81405ccb/SHPD6-5.9.aspx
@@ -1681,25 +2184,35 @@ RADIO WAVES,SHPD6-59,SHPD659,6,1.83,38.8,https://www.radiowaves.com/getmedia/122
 RADIO WAVES,SHPD6-6,SHPD66,6,1.83,39.1,https://www.radiowaves.com/getmedia/542466f7-b439-4bc1-8eeb-cd23cbfff1a1/SHPD6-6.aspx
 RADIO WAVES,SHPD6-6.4,SHPD664,6,1.83,38.9,https://www.radiowaves.com/getmedia/8ce005bb-c2e5-4edf-9cb8-289e91e58fdd/SHPD6-6.4.aspx
 RADIO WAVES,SHPD8-5.9,SHPD859,8,2.44,41.7,Comsearch's Frequency Coordination Database
-RADIO WAVES,SHPD8-6,SHPD86,8,2.44,41.9,https://www.everythingrf.com/product-datasheet/822-902-shpd8-6
+RADIO WAVES,SHPD8-6,SHPD86,8,2.44,42.1,https://www.radiowaves.com/getmedia/0dc97b93-99f0-425b-9e8b-f4a84ed3084a/SHP8-6.aspx
 RADIO WAVES,SHPD8-6.4,SHPD864,8,2.44,42.1,Comsearch's Frequency Coordination Database
+Commscope,SHPX3-6W,SHPX36W,3,0.91,33.6,Comsearch's Frequency Coordination Database
+Commscope,SHPX3-6WB,SHPX36WB,3,0.91,33.6,Comsearch's Frequency Coordination Database
 Commscope,SHPX4-6W,SHPX46W,4,1.22,35.5,https://www.commscope.com/globalassets/digizuite/263736-p360-shpx4-6w-6wh-external.pdf
 COMMSCOPE,SHPX6-6W,SHPX66W,6,1.83,39.4,Comsearch's Frequency Coordination Database
+Commscope,SHX10A,SHX10A,10,3.05,43.5,Comsearch's Frequency Coordination Database
+Commscope,SHX10B1,SHX10B1,10,3.05,42.7,Comsearch's Frequency Coordination Database
+"Cielo Networks, Inc.",Skylink-150W-6,SKYLINK150W6,,,,Indeterminate. 
+Solectek Corporation,SKYWAY-KM-6G-30M-512Q,SKYWAYKM6G30M512Q,,,,Radio - Indeterminate. 
+Solectek Corporation,SKYWAY-KM-6G-60M-4096Q,SKYWAYKM6G60M4096Q,,,,Radio - Indeterminate. 
+SIAE Microelettronica,SNKHPwb6L-AGS20-28M,SNKHPWB6LAGS2028M,,,,Radio - Indeterminate. 
 RADIO WAVES,SP4-5.9,SP459,4,1.22,36.2,https://www.radiowaves.com/en/product/sp4-5-9
 RFS,SP6-107A,SP6107A,,,,Model does not belong in this band.
 RADIO WAVES,SP6-5.9,SP659,6,1.83,39.2,https://www.radiowaves.com/getmedia/36695c42-a711-4a3b-bba8-b7a40bde172e/SP6-5.9.aspx
-Radiowaves,SP659,SP659,6,1.83,39.2,https://www.radiowaves.com/getmedia/36695c42-a711-4a3b-bba8-b7a40bde172e/SP6-5.9.aspx
 RADIO WAVES,SP6-59,SP659,6,1.83,39.2,https://www.radiowaves.com/getmedia/36695c42-a711-4a3b-bba8-b7a40bde172e/SP6-5.9.aspx
+Radiowaves,SP659,SP659,6,1.83,39.2,https://www.radiowaves.com/getmedia/36695c42-a711-4a3b-bba8-b7a40bde172e/SP6-5.9.aspx
+RADIO WAVES INC,SP6-5.9/6.0,SP65960,6,1.83,39.2,https://www.radiowaves.com/getmedia/36695c42-a711-4a3b-bba8-b7a40bde172e/SP6-5.9.aspx
 RFS,SP6-59A,SP659A,6,1.83,39.2,https://www.radiowaves.com/getmedia/36695c42-a711-4a3b-bba8-b7a40bde172e/SP6-5.9.aspx
 RFS,SP6-59B,SP659B,6,1.83,39.2,https://www.radiowaves.com/getmedia/36695c42-a711-4a3b-bba8-b7a40bde172e/SP6-5.9.aspx
-Radiowaves,SP664,SP664,6,1.83,39.2,https://www.radiowaves.com/getmedia/9abed637-a49d-44a6-a588-b2e3d343d8ec/SP6-6.4.aspx
 RADIO WAVES,SP6-64,SP664,6,1.83,39.2,https://www.radiowaves.com/en/product/sp6-6-4
+Radiowaves,SP664,SP664,6,1.83,39.2,https://www.radiowaves.com/getmedia/9abed637-a49d-44a6-a588-b2e3d343d8ec/SP6-6.4.aspx
 RFS,SP6-65,SP665,6,1.83,39.9,Comsearch's Frequency Coordination Database
 RFS,SP6-65A,SP665A,6,1.83,39.9,Comsearch's Frequency Coordination Database
 RFS,SP6-65B,SP665B,6,1.83,39.9,Comsearch's Frequency Coordination Database
 RADIO WAVES,SP8-5.9,SP859,8,2.44,41.9,Comsearch's Frequency Coordination Database
 RADIO WAVES,SP8-59,SP859,8,2.44,41.9,Comsearch's Frequency Coordination Database
 RADIO WAVES,SPD6-5.9,SPD659,6,1.83,38.9,https://www.radiowaves.com/en/product/spd6-5-9
+RADIO WAVES INC.,SPD6-6,SPD66,6,1.83,39.3,Comsearch's Frequency Coordination Database
 RADIO WAVES,SPD8-5.9,SPD859,8,2.44,41.6,Comsearch's Frequency Coordination Database
 GABRIEL,SR10-59ASE,SR1059ASE,10,3.05,43,Comsearch's Frequency Coordination Database
 GABRIEL,SR10-59SE,SR1059SE,10,3.05,43.2,Comsearch's Frequency Coordination Database
@@ -1733,7 +2246,9 @@ GABRIEL,SRDD10P-1J23107,SRDD10P1J23107,10,3.05,42.3,Comsearch's Frequency Coordi
 GABRIEL,SRDD10P-J59107A,SRDD10PJ59107A,10,3.05,42.3,Comsearch's Frequency Coordination Database
 GABRIEL,SRDD12P-J59107A,SRDD12PJ59107A,12,3.66,44.2,Comsearch's Frequency Coordination Database
 GABRIEL,SRDD6P-J59107,SRDD6PJ59107,6,1.83,37.8,Comsearch's Frequency Coordination Database
+DRAGONWAVE,S-SNT-L6G-72-C-A,SSNTL6G72CA,6,1.83,38.5,Assumed to be AANTL6G72CA
 RFS,SU4-59D,SU459D,4,1.22,35.3,https://www.rfsworld.com/pim/product/html/SU4-59DC2H
+RFS,SU4-65D,SU465D,4,1.22,36,Comsearch's Frequency Coordination Database
 RFS,SU4-W60,SU4W60,4,1.22,35.6,Comsearch's Frequency Coordination Database
 RFS,SU6-59A,SU659A,6,1.83,38.8,https://www.rfsworld.com/pim/product/html/SU6-59BC2H
 RFS,SU6-59B,SU659B,6,1.83,38.8,https://www.rfsworld.com/pim/product/html/SU6-59BC2H
@@ -1742,19 +2257,34 @@ RFS,SU6-B59,SU6B59,6,1.83,39.7,https://www.rfsworld.com/pim/product/html/SU6-65B
 RFS,SU6B-W60B,SU6BW60B,6,1.83,39.4,Comsearch's Frequency Coordination Database
 RFS,SU6-W60B,SU6W60B,6,1.83,39.1,Comsearch's Frequency Coordination Database
 RFS,SUX4-59A,SUX459A,4,1.22,34.5,https://www.rfsworld.com/pim/product/html/SUX4-59AC2H
+RFS,SUX4-59A / 4.0 ft,SUX459A40FT,4,1.22,34.5,Comsearch's Frequency Coordination Database
 RFS,SUX4-65A,SUX465A,4,1.22,35.3,https://www.rfsworld.com/pim/product/html/SUX4-65AC2H
 RFS,SUX4B-W60D,SUX4BW60D,4,1.22,35.7,Comsearch's Frequency Coordination Database
 RFS,SUX4-W60C,SUX4W60C,4,1.22,,Indeterminate. 
 RFS,SUX6-59B,SUX659B,6,1.83,38.6,https://www.rfsworld.com/pim/product/html/SUX6-59BC2H
 RFS,SUX6-59BC2H,SUX659BC2H,6,1.83,38.6,https://alliancecorporation.ca/images/documents/wireless-infrastructure-documents/RFS/Microwave_antennas/Alliance_distributor_RFS_Microwave_Antenna_SUX6-59BC2H.pdf
+RFS,SUX6-59B LF,SUX659BLF,6,1.83,38.6,Comsearch's Frequency Coordination Database
 RFS,SUX6-59B RF,SUX659BRF,6,1.83,38.6,https://www.rfsworld.com/pim/product/html/SUX6-59BC2H
 RFS,SUX6-65B,SUX665B,6,1.83,39.5,https://www.rfsworld.com/pim/product/html/SUX6-65BC2H
+GABRIEL ELECTRONICS,TH-10,TH10,10,3.05,43.5,Comsearch's Frequency Coordination Database
+Gabriel Electronics,TH-10-C,TH10C,10,3.05,43.7,Assumed to be TH-10C-59
+GABRIEL ELECTRONICS,TH-10C-59,TH10C59,10,3.05,43.7,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,TH-10C-59,TH10C59,10,3.05,43.7,Comsearch's Frequency Coordination Database
 <Faini Telecomminication S>,<THP 12 059 D WB>,THP12059DWB,4,1.22,35.5,https://www.fainitelecommunication.com/pdf2.php?id=215
 <Faini Telecommunication S>,<THP 12 059 D WB>,THP12059DWB,4,1.22,35.5,https://www.fainitelecommunication.com/pdf2.php?id=215
 Faini Telecommunication S,THP 12 059 D WB,THP12059DWB,4,1.22,35.5,https://www.fainitelecommunication.com/pdf2.php?id=215
+ERICSSON,TN6L-2XAAA-030-0128-T0A,TN6L2XAAA0300128T0A,,,,Radio - Indeterminate. 
+RFS,t PADX8-U57A,TPADX8U57A,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/PADX8-U57AC
+Trango Broadband,TrangoLINK-ApexPlus6,TRANGOLINKAPEXPLUS6,,,,Indeterminate. 
+"Trango Networks, LLC",TrangoLINK-Giga6,TRANGOLINKGIGA6,,,,Radio - Indeterminate. 
+ANDREW CORPORATION,TRP-6G-6AA,TRP6G6AA,,,,Indeterminate. 
+NEC,TRPL6-101A-IPASO-VR-AH-HP,TRPL6101AIPASOVRAHHP,,,,Radio - Indeterminate. 
+NEC AMERICA,TRP-L6G-101A,TRPL6G101A,,,,Indeterminate. 
+Commscope,TRP-U6G-900F ACM,TRPU6G900FACM,,,,Radio - Indeterminate. 
 TONGYU,TYA12U06WS,TYA12U06WS,4,1.22,35.6,http://www.belcoproducts.com/prodotti/wp-content/uploads/Tongyu-Microwave-Antenna-Catalogue.pdf
 TONGYU,TYA18U06WS,TYA18U06WS,6,1.83,39.4,http://www.belcoproducts.com/prodotti/wp-content/uploads/Tongyu-Microwave-Antenna-Catalogue.pdf
 TONGYU,TYA24U06WS,TYA24U06WS,8,2.44,41.7,http://www.belcoproducts.com/prodotti/wp-content/uploads/Tongyu-Microwave-Antenna-Catalogue.pdf
+RFS,UA10,UA10,10,3.05,,Indeterminate. 
 RFS,UA10-59,UA1059,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/UA10-59AC
 RFS,UA10 59A,UA1059A,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/UA10-59AC
 RFS,UA10-59A,UA1059A,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/UA10-59AC
@@ -1763,7 +2293,9 @@ RFS,UA10-59A (P),UA1059AP,10,3.05,43.4,https://www.rfsworld.com/pim/product/html
 CABLEWAVE SYSTEMS,UA10-59W,UA1059W,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/UA10-59AC
 RFS,UA10-59W,UA1059W,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/UA10-59AC
 CABLEWAVE SYSTEMS,UA10-65,UA1065,10,3.05,44.1,https://www.rfsworld.com/pim/product/html/UA10-65AC
+RFS,UA10-65A,UA1065A,10,3.05,44.1,Comsearch's Frequency Coordination Database
 RFS,UA10-W59A,UA10W59A,10,3.05,43.4,https://www.rfsworld.com/pim/product/html/UA10-59AC
+RFS,UA12-59A,UA1259A,12,3.66,45.1,Comsearch's Frequency Coordination Database
 RFS,UA12-65A,UA1265A,12,3.66,45.8,https://www.rfsworld.com/pim/product/html/UA12-65AC
 Cablewave,UA6-59,UA659,6,1.83,38.8,https://www.rfsworld.com/userfiles/pdf/299.pdf
 RFS,UA6-59A,UA659A,6,1.83,39,http://www.dadehnama.ir/uploads/4_313508659575390274.pdf
@@ -1788,23 +2320,29 @@ ANDREW,UA8-65AC,UA865AC,8,2.44,42.3,https://alliancecorporation.ca/images/docume
 RFS,UA8-65AC,UA865AC,8,2.44,42.3,https://www.rfsworld.com/pim/product/html/UA8-65AC
 RFS,UA8-65A(P) RF,UA865APRF,8,2.44,42.3,https://www.rfsworld.com/pim/product/html/UA8-65AC
 RFS,UA8-W59A,UA8W59A,8,2.44,41.6,http://www.dadehnama.ir/uploads/4_313508659575390274.pdf
+RFS,UAB-59B,UAB59B,,,,Indeterminate. 
 CABLEWAVE SYSTEMS,UAX10-59A RF,UAX1059ARF,10,3.05,43.2,https://www.rfsworld.com/pim/product/html/UXA10-59AC
 CABLEWAVE SYSTEMS,UAX10-59A RF,UAX1059ARF,10,3.05,43.2,https://www.rfsworld.com/pim/product/html/UXA10-59AC
+RFS,UAX8-59B LF,UAX859BLF,8,2.44,41.3,Typo should be UXA859BLF. Using that gain
 RFS,UAX8-59B RF,UAX859BRF,8,2.44,41.3,Typo should be UXA859BRF. Using that gain
 CABLEWAVE SYSTEMS,UAX8-59W RF C64007,UAX859WRFC64007,8,2.44,41.3,Typo should be UXA859WRFC64007. Using that gain. 
 RFS,UAX8-W59A RF,UAX8W59ARF,8,2.44,41.3,Typo should be UXA8W59ARF. Using that gain. 
+Nokia,UBT-I IDU HP,UBTIIDUHP,,,,Radio - Indeterminate. 
 GABRIEL,UCC10-59A LF,UCC1059ALF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59A RF,UCC1059ARF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59B L,UCC1059BL,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59B LF,UCC1059BLF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59B RF,UCC1059BRF,10,3.05,43.2,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,UCC10-59CSE,UCC1059CSE,10,3.06,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59 CSE (L),UCC1059CSEL,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59C SE L,UCC1059CSEL,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC1059CSE L,UCC1059CSEL,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59CSE L,UCC1059CSEL,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59CSE(L),UCC1059CSEL,10,3.05,43.2,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,UCC10-59CSE LF,UCC1059CSELF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59C SE R,UCC1059CSER,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59CSE R,UCC1059CSER,10,3.05,43.2,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,UCC10-59CSE RF,UCC1059CSERF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59 L,UCC1059L,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10-59 LF,UCC1059LF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL ELECTRONICS,UCC10-59 R,UCC1059R,10,3.05,43.2,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
@@ -1813,8 +2351,8 @@ GABRIEL,UCC10P-59BSE,UCC10P59BSE,10,3.05,43.2,Likely typo.  Used this coordinati
 GABRIEL,UCC10W-59B RF,UCC10W59BRF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC10X-59DSE RF,UCC10X59DSERF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 GABRIEL,UCC12-59A L,UCC1259AL,12,3.66,44.8,Comsearch's Frequency Coordination Database
-Gabriel Electronics,UCC12-59A (LF),UCC1259ALF,12,3.66,44.8,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
 GABRIEL,UCC12-59A LF,UCC1259ALF,12,3.66,44.8,Comsearch's Frequency Coordination Database
+Gabriel Electronics,UCC12-59A (LF),UCC1259ALF,12,3.66,44.8,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
 GABRIEL,UCC12-59A RF,UCC1259ARF,12,3.66,44.8,Comsearch's Frequency Coordination Database
 GABRIEL ELECTRONICS,UCC12-59BSE(LF),UCC1259BSELF,12,3.66,44.8,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
 GABRIEL ELECTRONICS,UCC12-59BSE(R),UCC1259BSER,12,3.66,44.8,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
@@ -1833,15 +2371,16 @@ GABRIEL,UCC6-59ASE(RF),UCC659ASERF,6,1.83,38.6,Comsearch's Frequency Coordinatio
 GABRIEL,UCC6X-59A,UCC6X59A,6,1.83,38.6,Comsearch's Frequency Coordination Database
 GABRIEL,UCC6X-59A (R),UCC6X59AR,6,1.83,38.6,Comsearch's Frequency Coordination Database
 GABRIEL,UCC8-59A,UCC859A,8,2.44,41.1,Comsearch's Frequency Coordination Database
-Gabriel Electronics,UCC8-59A (LF),UCC859ALF,8,2.44,41.1,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
+CABLEWAVE,UCC8-59A LF,UCC859ALF,8,2.44,41.1,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
 GABRIEL,UCC859A LF,UCC859ALF,8,2.44,41.1,Comsearch's Frequency Coordination Database
 GABRIEL,UCC8-59A LF,UCC859ALF,8,2.44,41.1,Comsearch's Frequency Coordination Database
 GABRIEL,UCC8-59A LF,UCC859ALF,8,2.44,41.1,Comsearch's Frequency Coordination Database
-CABLEWAVE,UCC8-59A LF,UCC859ALF,8,2.44,41.1,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
+Gabriel Electronics,UCC8-59A (LF),UCC859ALF,8,2.44,41.1,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
 Gabriel,UCC8-59A (RF),UCC859ARF,8,2.44,41.1,https://its.ntia.gov/umbraco/surface/download/publication?reportNumber=90-267_ocr.pdf
 GABRIEL,UCC8-59A RF,UCC859ARF,8,2.44,41.1,Comsearch's Frequency Coordination Database
 GABRIEL,UCC8-59ASE RF,UCC859ASERF,8,2.44,41.1,Comsearch's Frequency Coordination Database
 GABRIEL,UCC8-59B LF,UCC859BLF,8,2.44,41.1,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,UCC8-59BSE,UCC859BSE,8,2.44,41.1,Comsearch's Frequency Coordination Database
 GABRIEL,UCC8-59BSE (LF),UCC859BSELF,8,2.44,41.1,Comsearch's Frequency Coordination Database
 GABRIEL,UCC8-59BSE LF,UCC859BSELF,8,2.44,41.1,Comsearch's Frequency Coordination Database
 GABRIEL,UCC8-59BSE(R),UCC859BSER,8,2.44,41.1,Comsearch's Frequency Coordination Database
@@ -1851,6 +2390,7 @@ GABRIEL,UCC8W-59SE LF,UCC8W59SELF,8,2.44,41.1,Comsearch's Frequency Coordination
 GABRIEL,UCC8X-59CSE RF,UCC8X59CSERF,8,2.44,41.1,Comsearch's Frequency Coordination Database
 GABRIEL,UCC8x-59CSE RF,UCC8X59CSERF,8,2.44,41.1,Comsearch's Frequency Coordination Database
 RFS,UDA10-59A,UDA1059A,10,3.05,43.2,Comsearch's Frequency Coordination Database
+RFS,UDA10-59A LF,UDA1059ALF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 RFS,UDA10-59A RF,UDA1059ARF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,UDA10-59C RF,UDA1059CRF,10,3.05,43.2,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,UDA10-59C-RF,UDA1059CRF,10,3.05,43.2,Comsearch's Frequency Coordination Database
@@ -1873,6 +2413,9 @@ CABLEWAVE SYSTEMS,UDA8-59C LF,UDA859CLF,8,2.44,41.3,Comsearch's Frequency Coordi
 CABLEWAVE SYSTEMS,UDA8-59C RF,UDA859CRF,8,2.44,41.3,Comsearch's Frequency Coordination Database
 RFS,UDA8-65A RF,UDA865ARF,8,2.44,42.2,Comsearch's Frequency Coordination Database
 CABLEWAVE SYSTEMS,UDA8-65 LF,UDA865LF,8,2.44,42.2,Comsearch's Frequency Coordination Database
+Commscope,UGX10R-59C,UGX10R59C,10,3.05,44.3,Comsearch's Frequency Coordination Database
+Commscope,UGX12R-59D,UGX12R59D,12,3.66,45.8,Comsearch's Frequency Coordination Database
+Commscope,UGXR10-59C,UGXR1059C,10,3.05,44.3,Used UGX10R-59C. 
 COMMSCOPE,UH6-59WB RF,UH659WBRF,6,1.83,,Indeterminate. Third character has multiple options. 
 RFS,UHA8-59A LF,UHA859ALF,8,2.44,41.3,Typo should be UDA859ALF. Using that gain. 
 COMMSCOPE,UHK6-59K RF,UHK659KRF,6,1.83,,Indeterminate. Third character has multiple options. 
@@ -1881,14 +2424,16 @@ COMMSCOPE,UHP10-59W,UHP1059W,10,3.05,43.3,https://www.digchip.com/datasheets/par
 COMMSCOPE,UHP10-59W LF,UHP1059WLF,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP10-59W RF,UHP1059WRF,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHP10-59W RF,UHP1059WRF,10,3.05,43.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,UHP12-59W,UHP1259W,12,3.66,45.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP12-59W R,UHP1259WR,12,3.66,45.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP12-59W RF,UHP1259WRF,12,3.66,45.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHP12-59W RF,UHP1259WRF,12,3.66,45.2,Comsearch's Frequency Coordination Database
 ANDREW,UHP6-59,UHP659,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope/Andrew,UHP659W,UHP659W,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP6-59W,UHP659W,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,UHP659W,UHP659W,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP6-59WA R,UHP659WAR,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP6-59WA RF,UHP659WARF,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+CommScope,UHP6-59WB,UHP659WB,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP6-59WB LF,UHP659WBLF,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHP6-59WB LF,UHP659WBLF,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP6-59WB RF,UHP659WBRF,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1897,15 +2442,15 @@ ANDREW,UHP6-59W LF,UHP659WLF,6,1.83,39.3,https://www.digchip.com/datasheets/part
 COMMSCOPE,UHP6-59W LF,UHP659WLF,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP6-59W R,UHP659WR,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP6-59W RF,UHP659WRF,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHP6-59W RF,UHP659WRF,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP6-59W-RF,UHP659WRF,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHP6-59W RF,UHP659WRF,6,1.83,39.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP8 50W LF,UHP850WLF,8,2.44,,Indeterminate. Band designator 50 has multiple options. 
-Commscope/Andrew,UHP859W,UHP859W,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP8-59W,UHP859W,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,UHP859W,UHP859W,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP8 59W LF,UHP859WLF,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP8-59W LF,UHP859WLF,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHP8-59W LF,UHP859WLF,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP8-59WLF,UHP859WLF,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHP8-59W LF,UHP859WLF,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP8-59W RF,UHP859WRF,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHP8-59W RF,UHP859WRF,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHP8-59W RW,UHP859WRW,8,2.44,41.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1917,16 +2462,18 @@ Gabriel,UHR-10C,UHR10C,10,3.05,44.2,Comsearch's Frequency Coordination Database
 GABRIEL,UHR-6-B,UHR6B,6,1.83,39.9,Comsearch's Frequency Coordination Database
 ANDREW,UHX10-49J RF,UHX1049JRF,10,3.05,,Indeterminate. Band designator 49 has multiple options. 
 COMMSCOPE,UHX10-569K LF,UHX10569KLF,10,3.05,,Indeterminate. Band designator 569 has multiple options. 
-ANDREW,UHX10-58J LF,UHX1058JLF,10,3.05,42.1,https://www.launch3telecom.com/commscopeandrew/uhx1058w.html
-ANDREW,UHX10-58WA,UHX1058WA,10,3.05,42.1,https://www.launch3telecom.com/commscopeandrew/uhx1058w.html
-Commscope/Andrew,UHX1059,UHX1059,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,UHX10-58J LF,UHX1058JLF,10,3.05,43.2,https://www.launch3telecom.com/commscopeandrew/uhx1058w.html
+COMMSCOPE,UHX10-58W,UHX1058W,10,3.05,43.2,Comsearch's Frequency Coordination Database
+ANDREW,UHX10-58WA,UHX1058WA,10,3.05,43.2,https://www.launch3telecom.com/commscopeandrew/uhx1058w.html
 ANDREW,UHX10-59,UHX1059,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,UHX1059,UHX1059,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59B RF,UHX1059BRF,10,3.05,43.2,Used UHX10-59
 ANDREW,UHX10 59C LF,UHX1059CLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59C LF,UHX1059CLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59C LF,UHX1059CLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,UHX10-59C RF,UHX1059CRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,UHX10-59C RF,UHX1059CRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10?59C RF,UHX1059CRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW,UHX10-59C RF,UHX1059CRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW,UHX10-59C RF,UHX1059CRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59C RF,UHX1059CRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59D,UHX1059D,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59-D3A-LEFT,UHX1059D3ALEFT,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1935,8 +2482,8 @@ ANDREW,UHX10-59D LF,UHX1059DLF,10,3.05,43.2,https://www.digchip.com/datasheets/p
 COMMSCOPE,UHX10-59D LF,UHX1059DLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59D RF,UHX1059DRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59D RF,UHX1059DRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59D RF,UHX1059DRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Andrew Corporation,UHX10-59D(RF),UHX1059DRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59D RF,UHX1059DRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59E LF,UHX1059ELF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59E RF,UHX1059ERF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59E RF,UHX1059ERF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -1944,61 +2491,61 @@ COMMSCOPE,UHX10-59F RF,UHX1059FRF,10,3.05,43.2,https://www.digchip.com/datasheet
 ANDREW,UHX10-59H,UHX1059H,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59H LF,UHX1059HLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59H LF,UHX1059HLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59H LF,UHX1059HLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Andrew Corporation,UHX10-59H LF,UHX1059HLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59H LF,UHX1059HLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59H RF,UHX1059HRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59H RF,UHX1059HRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59H RF,UHX1059HRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX1059J,UHX1059J,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59J,UHX1059J,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX1059J,UHX1059J,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59J,UHX1059J,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Andrew Corporation,UHX10-59J L,UHX1059JL,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW CORPORATION,UHX10-59JL,UHX1059JL,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59J LF,UHX1059JLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59J LF,UHX1059JLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59J LF,UHX1059JLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59J LF,UHX1059JLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Andrew Corporation,UHX10-59J LF,UHX1059JLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59j LF,UHX1059JLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59JLF,UHX1059JLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corporation,UHX10-59J LF,UHX1059JLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59J LF,UHX1059JLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59J R,UHX1059JR,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX 10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10 59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10?¡59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59 J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope,UHX10-59 J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59J (RF),UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX1059J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Andrew Corporation,UHX10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Andrew Corporation,UHX10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59JRF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59J-RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corporation,UHX10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corporation,UHX10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX 10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10?¡59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,UHX10-59 J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX1059J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59J RF,UHX1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59K,UHX1059K,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59K,UHX1059K,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59K LF,UHX1059KLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59K LF,UHX1059KLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX 10-59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10?59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10?¡59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59K (RF),UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX1059K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59K Rf,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59K- RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59-K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59KRF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59K-RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX 10-59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10?¡59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10?59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX1059K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59K RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59K- RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59KRF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59K-RF,UHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59L,UHX1059L,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59 LF,UHX1059LF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59 (RF),UHX1059RF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59 RF,UHX1059RF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59 (RF),UHX1059RF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59SWB,UHX1059SWB,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59W,UHX1059W,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59W,UHX1059W,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2015,20 +2562,20 @@ COMMSCOPE,UHX10-59WB-RF,UHX1059WBRF,10,3.05,43.2,https://www.digchip.com/datashe
 ANDREW,UHX10-59W LF,UHX1059WLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59W LF,UHX1059WLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59W LF,UHX1059WLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59W LF,UHX1059WLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Andrew Corporation,UHX10-59W LF,UHX1059WLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope,UHX10-59W LF,UHX1059WLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59W-LF,UHX1059WLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corporation,UHX10-59W LF,UHX1059WLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59W LF,UHX1059WLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,UHX10-59W LF,UHX1059WLF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59W-P3A,UHX1059WP3A,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59W-P3A (LF),UHX1059WP3ALF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59W-P3A (RF),UHX1059WP3ARF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX10-59W-P3A (RF),UHX1059WP3ARF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59W RF,UHX1059WRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX10-59W RF,UHX1059WRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,uhx10-59w rf,UHX1059WRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59w rf,UHX1059WRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59WRF,UHX1059WRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-59W-RF,UHX1059WRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX10-59W RF,UHX1059WRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX10-5J LF,UHX105JLF,10,3.05,,Indeterminate. Band designator 5 has multiple options. 
 ANDREW,UHX10-65,UHX1065,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX10-65D,UHX1065D,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
@@ -2037,15 +2584,15 @@ ANDREW,UHX10-65-D3A-RIGHT,UHX1065D3ARIGHT,10,3.05,44,https://www.digchip.com/dat
 ANDREW,UHX10-65D LF,UHX1065DLF,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX10-65D RF,UHX1065DRF,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX10-65D RF,UHX1065DRF,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,UHX1065E,UHX1065E,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX10-65E,UHX1065E,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,UHX1065E,UHX1065E,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX10-65E LF,UHX1065ELF,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX10-65E LF,UHX1065ELF,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX10-65E RF,UHX1065ERF,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,UHX10-65E RF,UHX1065ERF,10,3.05,44,Comsearch's Frequency Coordination Database
-COMMSCOPE,UHX10-65E RF,UHX1065ERF,10,3.05,44,Comsearch's Frequency Coordination Database
 ANDREW,UHX10-65E- RF,UHX1065ERF,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX10-65E-RF,UHX1065ERF,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,UHX10-65E RF,UHX1065ERF,10,3.05,44,Comsearch's Frequency Coordination Database
+COMMSCOPE,UHX10-65E RF,UHX1065ERF,10,3.05,44,Comsearch's Frequency Coordination Database
 COMMSCOPE,UHX10-65-P3A (RF),UHX1065P3ARF,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX10-65 RF,UHX1065RF,10,3.05,44,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 Andrew Corporation,UHX10C-59C RF,UHX10C59CRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2058,24 +2605,24 @@ ANDREW,UHX10X-65A RF,UHX10X65ARF,10,3.05,43.8,Comsearch's Frequency Coordination
 ANDREW,UHX10X-65 RF,UHX10X65RF,10,3.05,43.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,UHX10X-65 RF,UHX10X65RF,10,3.05,43.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,UHX10X-65-RF,UHX10X65RF,10,3.05,43.8,Comsearch's Frequency Coordination Database
-Commscope/Andrew,UHX1259,UHX1259,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59,UHX1259,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,UHX1259,UHX1259,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59C,UHX1259C,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59C RF,UHX1259CRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59D,UHX1259D,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59D LF,UHX1259DLF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX12-59D LF,UHX1259DLF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX1259D RF,UHX1259DRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59D RF,UHX1259DRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX1259D RF,UHX1259DRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX12-59D RF,UHX1259DRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX1259DRF,UHX1259DRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59E,UHX1259E,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Andrew Corporation,UHX12-59E (LF),UHX1259ELF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59E LF,UHX1259ELF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corporation,UHX12-59E (LF),UHX1259ELF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX12-59E LF,UHX1259ELF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Andrew Corporation,UHX12-59E (RF),UHX1259ERF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX12-59E RF,UHX1259ERF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Andrew Corporation,UHX12-59E(RF),UHX1259ERF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX12-59E RF,UHX1259ERF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59F RF,UHX1259FRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX12-59F RF,UHX1259FRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59H,UHX1259H,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2089,9 +2636,9 @@ ANDREW,UHX12-59J LF,UHX1259JLF,12,3.66,44.8,https://www.digchip.com/datasheets/p
 COMMSCOPE,UHX12-59J LF,UHX1259JLF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59J (RF),UHX1259JRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59J RF,UHX1259JRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX12-59J RF,UHX1259JRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX12-59J RF,UHX1259JRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,uhx12-59j rf,UHX1259JRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX12-59J RF,UHX1259JRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX12-59J RF,UHX1259JRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59 LF,UHX1259LF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59 RF,UHX1259RF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX12-59W,UHX1259W,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2099,35 +2646,48 @@ ANDREW,UHX12-59W LF,UHX1259WLF,12,3.66,44.8,https://www.digchip.com/datasheets/p
 ANDREW,UHX12-59W LF,UHX1259WLF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX12-59W LF,UHX1259WLF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Commscope,UHX12-59W LF,UHX1259WLF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX 12-59W RF,UHX1259WRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX12-59W RF,UHX1259WRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX 12-59W RF,UHX1259WRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX12-59W RF,UHX1259WRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Commscope/Andrew,UHX1265,UHX1265,12,3.66,45.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX12-65J,UHX1265J,12,3.66,45.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX12-65J RF,UHX1265JRF,12,3.66,45.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX12-6W,UHX126W,12,3.66,,Indeterminate. Band designator 6W unknown. 
 COMMSCOPE,UHX15-59D RF,UHX1559DRF,15,4.57,46.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX15-59H LF,UHX1559HLF,15,4.57,46.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Andrew Corporation,UHX15-59H LF,UHX1559HLF,15,4.57,46.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX15-59H LF,UHX1559HLF,15,4.57,46.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX15-59H RF,UHX1559HRF,15,4.57,46.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX15-59H RF,UHX1559HRF,15,4.57,46.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX15-59H RF,UHX1559HRF,15,4.57,46.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX15-59H RF,UHX1559HRF,15,4.57,46.4,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX15-65E RF,UHX1565ERF,15,4.57,46.9,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+Commscope,UHX5-59L RF,UHX559LRF,,,,Diameter indeterminate
+Commscope,UHX56-59WB RF,UHX5659WBRF,,,,Diameter indeterminate
+Andrew,UHX-59J,UHX59J,,,,Indeterminate. 
+Commscope,UHX-59J RF,UHX59JRF,,,,Indeterminate. 
+Andrew Corporation,UHX-59K,UHX59K,,,,Indeterminate. 
+Andrew Corp.,UHX-59K LF,UHX59KLF,,,,Indeterminate. 
+MICROWAVE NETWORKS INC,UHX-59K R,UHX59KR,,,,Indeterminate. 
+Andrew Corp,UHX-59K RF,UHX59KRF,,,,Indeterminate. 
+Commscope,UHX-59L RF,UHX59LRF,,,,Indeterminate. 
+COMMSCOPE,UHX-59WA RF,UHX59WARF,,,,Indeterminate. 
+COMSCOPE,UHX-59WB RF,UHX59WBRF,,,,Indeterminate. 
+Commscope,UHX-59W RF,UHX59WRF,,,,Indeterminate. 
 ANDREW,UHX6059J RF,UHX6059JRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-059L RF,UHX6059LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,UHX6-107K RF,UHX6107KRF,6,1.83,,11 GHz Antenna
 ANDREW,UHX6-56H R,UHX656HR,6,1.83,,Indeterminate. Band designator 56 unknown. 
 COMMSCOPE,UHX6-56L RF,UHX656LRF,6,1.83,,Indeterminate. Band designator 56 unknown. 
-Commscope/Andrew,UHX659,UHX659,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59,UHX659,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,UHX659,UHX659,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59B RF,UHX659BRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59C,UHX659C,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59C LF,UHX659CLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59C LF,UHX659CLF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,UHX6 59C RF,UHX659CRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59C RF,UHX659CRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6-59C RF,UHX659CRF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,UHX6-59C-RF,UHX659CRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX6-59C RF,UHX659CRF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,UHX6-59D RF,UHX659DRF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,UHX6-59H,UHX659H,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59H L,UHX659HL,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2137,22 +2697,22 @@ ANDREW,UHX6-59H R,UHX659HR,6,1.83,38.8,https://www.digchip.com/datasheets/parts/
 ANDREW,UHX6-59H RF,UHX659HRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59H RF,UHX659HRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59H RF,UHX659HRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6-59H RF,UHX659HRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Andrew Corporation,UHX6-59H RF,UHX659HRF,6,1.83,38.8,https://www.launch3telecom.com/shared_media/datasheet/commscope/uhx6-59-l_specifications.pdf
 ANDREW,UHX6-59H-RF,UHX659HRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corporation,UHX6-59H RF,UHX659HRF,6,1.83,38.8,https://www.launch3telecom.com/shared_media/datasheet/commscope/uhx6-59-l_specifications.pdf
+COMMSCOPE,UHX6-59H RF,UHX659HRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59J,UHX659J,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6 59J LF,UHX659JLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW CORPORATION,UHX6-59J (LF),UHX659JLF,6,1.83,38.8,https://objects.eanixter.com/PD357070.PDF
 ANDREW,UHX6-59J LF,UHX659JLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW CORPORATION,UHX6-59J (LF),UHX659JLF,6,1.83,38.8,https://objects.eanixter.com/PD357070.PDF
 COMMSCOPE,UHX6-59J LF,UHX659JLF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,UHX6-59J-LF,UHX659JLF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,UHX6 59J RF,UHX659JRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59J (RF),UHX659JRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59J RF,UHX659JRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59J RF,UHX659JRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6-59J RF,UHX659JRF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,UHX6-59JRF,UHX659JRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59J-RF,UHX659JRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX6-59J RF,UHX659JRF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,UHX6-59J-RF,UHX659JRF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,UHX6-59J VLF,UHX659JVLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59K,UHX659K,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2160,18 +2720,18 @@ ANDREW,UHX6-59K L,UHX659KL,6,1.83,38.8,https://www.digchip.com/datasheets/parts/
 ANDREW,UHX6-59K LE,UHX659KLE,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59K LF,UHX659KLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59K LF,UHX659KLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6-59K LF,UHX659KLF,6,1.83,38.8,Comsearch's Frequency Coordination Database
-Andrew Corporation,UHX6-59K LF,UHX659KLF,6,1.83,38.8,https://objects.eanixter.com/PD357070.PDF
 ANDREW,UHX6-59K lF,UHX659KLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59KLF,UHX659KLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Andrew Corporation,UHX6-59K LF,UHX659KLF,6,1.83,38.8,https://objects.eanixter.com/PD357070.PDF
+COMMSCOPE,UHX6-59K LF,UHX659KLF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,UHX6-59K-LF,UHX659KLF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,UHX6-59K R,UHX659KR,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59 K RF,UHX659KRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59K (RF),UHX659KRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59K RF,UHX659KRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6-59K RF,UHX659KRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59KRF,UHX659KRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59K-RF,UHX659KRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX6-59K RF,UHX659KRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59K-RF,UHX659KRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59L,UHX659L,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59L,UHX659L,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2181,14 +2741,15 @@ ANDREW,UHX6-59L LF,UHX659LLF,6,1.83,38.8,https://www.digchip.com/datasheets/part
 ANDREW,UHX6-59L LF,UHX659LLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59L LF,UHX659LLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59L LF,UHX659LLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,UHX6-59L R,UHX659LR,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59L RE,UHX659LRE,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6?59L RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59L RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59L RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6-59L RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6-59L RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59L- RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX-6-59L RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX6?59L RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX6-59L RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX6-59L RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59LRF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59L-RF,UHX659LRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59-P3A/L (LF),UHX659P3ALLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2198,8 +2759,8 @@ COMMSCOPE,UHX6-59 RF,UHX659RF,6,1.83,38.8,https://www.digchip.com/datasheets/par
 COMMSCOPE,UHX6-59-RF,UHX659RF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59 RFL,UHX659RFL,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59W,UHX659W,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope,UHX659WA,UHX659WA,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59WA,UHX659WA,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,UHX659WA,UHX659WA,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59WA,UHX659WA,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59WA L,UHX659WAL,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59WA LF,UHX659WALF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2211,12 +2772,12 @@ ANDREW,UHX6-59WB LF,UHX659WBLF,6,1.83,38.8,https://www.digchip.com/datasheets/pa
 COMMSCOPE,UHX6-59WB LF,UHX659WBLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59WB LF,UHX659WBLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6?59WB RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6?59WB RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59WB RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,UHX6-59WB-RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX6?59WB RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59WB RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59WB RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHx6-59WB RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW,UHX6-59WB-RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59WB-RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59-WB-RF,UHX659WBRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59WC,UHX659WC,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2232,21 +2793,22 @@ ANDREW,UHX6-59W-P3A/B (LF),UHX659WP3ABLF,6,1.83,38.8,https://www.digchip.com/dat
 COMMSCOPE,UHX6-59W-P3A/B (LF),UHX659WP3ABLF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59W P3A/B RF,UHX659WP3ABRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59W-P3A/B (RF),UHX659WP3ABRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6-59W-P3A/B (RF),UHX659WP3ABRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59W-P3A/B RF,UHX659WP3ABRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX6-59W-P3A/B (RF),UHX659WP3ABRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59W R,UHX659WR,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6-59W (RF),UHX659WRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59W RF,UHX659WRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX6-59W RF,UHX659WRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX6-59W-RF,UHX659WRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX6-59W (RF),UHX659WRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX6-59W RF,UHX659WRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX6-59W-RF,UHX659WRF,6,1.83,38.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope/Andrew,UHX665,UHX665,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+Andrew Corp,UHX-65D RF,UHX65DRF,,,,Indeterminate. 
 ANDREW,UHX6-65,UHX665,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+Commscope/Andrew,UHX665,UHX665,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65A RF,UHX665ARF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6-65D,UHX665D,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65D RF,UHX665DRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,UHX6-65D RF,UHX665DRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65d rf,UHX665DRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,UHX6-65D RF,UHX665DRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65E,UHX665E,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65E L,UHX665EL,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65E LF,UHX665ELF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
@@ -2254,29 +2816,31 @@ COMMSCOPE,UHX6-65E LF,UHX665ELF,6,1.83,39.5,https://www.digchip.com/datasheets/p
 COMMSCOPE,UHX6-65E-LF,UHX665ELF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65E R,UHX665ER,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65E RF,UHX665ERF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,UHX6-65E RF,UHX665ERF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65E-RF,UHX665ERF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,UHX6-65E RF,UHX665ERF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6-65E-RF,UHX665ERF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6-65F,UHX665F,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6-65F LE,UHX665FLE,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65F LF,UHX665FLF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6-65F LF,UHX665FLF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6-65F R,UHX665FR,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+ANDREW,UHX6-65F RF,UHX665FRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6 65F RF,UHX665FRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6?65F RF,UHX665FRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-ANDREW,UHX6-65F RF,UHX665FRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6-65F RF,UHX665FRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6-65F RF,UHX665FRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6-65F-RF,UHX665FRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-65 LF,UHX665LF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX6-65-P3A/F (RF),UHX665P3AFRF,6,1.83,39.5,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX6-69L,UHX669L,6,1.83,39.5,Typo should be UHX665LF Using that gain
+Commscope,UHX6-6W,UHX66W,6,1.83,,Band indeterminate
 COMMSCOPE,UHX6-9L RF,UHX69LRF,6,1.83,,Indeterminate. Band designator 9 unknown. 
+Commscope,UHX-8,UHX8,8,2.44,,8 foot antenna. Various bands have gain range of 40.5 - 42.0
 COMMSCOPE,UHX8-56J RF,UHX856JRF,8,2.44,,Indeterminate. Band designator 58 unknown. 
 ANDREW,UHX8-58J RF,UHX858JRF,8,2.44,41.3,Typo should be UHX859JRF Using that gain
 COMMSCOPE,UHX8-58J RF,UHX858JRF,8,2.44,41.3,Typo should be UHX859JRF Using that gain
-Commscope/Andrew,UHX859,UHX859,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59,UHX859,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope/Andrew,UHX859,UHX859,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59C LF,UHX859CLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59C LF,UHX859CLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8 - 59C RF,UHX859CRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2287,9 +2851,10 @@ COMMSCOPE,UHX8-59D LF,UHX859DLF,8,2.44,41.3,https://www.digchip.com/datasheets/p
 ANDREW,UHX8-59D RF,UHX859DRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59D RF,UHX859DRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59D RF,UHX859DRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59D RF,UHX859DRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 Andrew,UHX8-59D RF,UHX859DRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59D RF,UHX859DRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59E,UHX859E,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59E LF,UHX859ELF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59E-R,UHX859ER,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59E RF,UHX859ERF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59E RF,UHX859ERF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2298,27 +2863,27 @@ ANDREW,UHX8-59H,UHX859H,8,2.44,41.3,https://www.digchip.com/datasheets/parts/dat
 ANDREW,UHX-8-59H,UHX859H,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8 59H LF,UHX859HLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8?59H LF,UHX859HLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59H (LF),UHX859HLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59H LF,UHX859HLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59H LF,UHX859HLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHx8-59H LF,UHX859HLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59h LF,UHX859HLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59H-LF,UHX859HLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59H (LF),UHX859HLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59H LF,UHX859HLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59H LP,UHX859HLP,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8- 59H RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59H (RF),UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59H (RF),UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59H RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59H RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59H RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-GABRIEL,UHX8-59H RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW CORP,UHX8-59H RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59HRF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59H-RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-Commscope,UHX859J,UHX859J,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW CORP,UHX8-59H RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8- 59H RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59H (RF),UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59H RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+GABRIEL,UHX8-59H RF,UHX859HRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J,UHX859J,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59J,UHX859J,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59-J,UHX859J,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,UHX859J,UHX859J,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59J,UHX859J,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8--59J,UHX859J,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J F,UHX859JF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J L,UHX859JL,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2326,47 +2891,47 @@ ANDREW,UHX 8-59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/par
 ANDREW,UHX8 - 59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8 59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8 -59JLF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8?59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59 J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J (LF),UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,UHX8-59JLF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+ANDREW,UHX8-59J-LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8?59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 RFS,UHX8-59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59J LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW,UHX8-59JLF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-ANDREW,UHX8-59J-LF,UHX859JLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J R,UHX859JR,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8- 59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8/-59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8?59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-?¡59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J (RF),UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59j RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,uhx8-59j rf,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59JRF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59JRF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59J-RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8- 59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8/-59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-?¡59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8?59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59J RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,uhx8-59j rf,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59JRF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59J-RF,UHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59K LF,UHX859KLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59KLF,UHX859KLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59K RF,UHX859KRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59K RF,UHX859KRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59KRF,UHX859KRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59K RF,UHX859KRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59KRF,UHX859KRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59 (LF),UHX859LF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59 LF,UHX859LF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59 (LF),UHX859LF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59L LF,UHX859LLF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59L RF,UHX859LRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59 (RF),UHX859RF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59 RF,UHX859RF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59-RF,UHX859RF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59 (RF),UHX859RF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59W,UHX859W,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59W,UHX859W,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59WA,UHX859WA,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2388,24 +2953,24 @@ COMMSCOPE,UHX8-59W-P3A (LF),UHX859WP3ALF,8,2.44,41.7,https://www.digchip.com/dat
 ANDREW,UHX8-59W-P3A (RF),UHX859WP3ARF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-59W-P3A (RF),UHX859WP3ARF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59W RD,UHX859WRD,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59 W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59W (RF),UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,uhx8-59W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59w rf,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59w RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59W rf,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
-COMMSCOPE,UHX8-59-W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59W/RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59WRF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-59W-RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59 W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59W (RF),UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+COMMSCOPE,UHX8-59-W RF,UHX859WRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UHX8-5D RF,UHX85DRF,8,2.44,,Indeterminate.  Band designator 5 unknown. 
 ANDREW,UHX8-5H RF,UHX85HRF,8,2.44,,Indeterminate.  Band designator 5 unknown. 
-Commscope/Andrew,UHX865,UHX865,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65,UHX865,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+Commscope/Andrew,UHX865,UHX865,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65B LF,UHX865BLF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65D,UHX865D,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8 65D LF,UHX865DLF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
@@ -2416,28 +2981,32 @@ ANDREW,UHX8-65D RF,UHX865DRF,8,2.44,42,https://www.digchip.com/datasheets/parts/
 COMMSCOPE,UHX8-65D RF,UHX865DRF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX865E,UHX865E,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65E,UHX865E,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,UHX8-65E,UHX865E,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65e,UHX865E,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,UHX8-65E,UHX865E,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX8-65E EF,UHX865EEF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65E LF,UHX865ELF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX8-65E LF,UHX865ELF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65E R,UHX865ER,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65E RF,UHX865ERF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65E RF,UHX865ERF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
-COMMSCOPE,UHX8-65E RF,UHX865ERF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65E- RF,UHX865ERF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+COMMSCOPE,UHX8-65E RF,UHX865ERF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX8-65E-RF,UHX865ERF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 ANDREW,UHX8-65F,UHX865F,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX8-65 (LF),UHX865LF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX8-65-P3A (LF),UHX865P3ALF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX8-65-P3A (RF),UHX865P3ARF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
 COMMSCOPE,UHX8-65 (RF),UHX865RF,8,2.44,42,https://www.digchip.com/datasheets/parts/datasheet/3751/HP10-65E-pdf.php
+ANDREW CORP,UHX8&8-59W L,UHX8859WL,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UHX8-86E LF,UHX886ELF,8,2.44,,Indeterminate.  Band designator 86 unknown. 
+ANDREW,UHX9-59J RF,UHX959JRF,,,,Indeterminate. 
+Andrew Corporation,UHX9-59W LF,UHX959WLF,,,,Indeterminate. 
 RFS,UHXA6-59B LF,UHXA659BLF,6,1.83,,Indeterminate.  UHXA unknown could be UHX or UXA. 
 RFS,UHXA6-59B RF,UHXA659BRF,6,1.83,,Indeterminate.  UHXA unknown could be UHX or UXA. 
 RFS,UHXA6-W57A RF,UHXA6W57ARF,6,1.83,,Indeterminate.  UHXA unknown could be UHX or UXA. 
 RFS,UHXA8-W59A RF,UHXA8W59ARF,8,2.44,,Indeterminate.  UHXA unknown could be UHX or UXA. 
 COMMSCOPE,UHXC10-59K RF,UHXC1059KRF,10,3.05,43.2,Typo should be UHX1059KRF
+Andrew Corporation,UHZ8-59J RF,UHZ859JRF,8,2.44,41.3,Used UHX8-59J RF
 ANDREW,UJX8-59J RF,UJX859JRF,8,2.44,41.3,Typo should be UHX859JRF Using that gain
 ERICSSON,UKY 220 11/DC12,UKY22011DC12,4,1.22,35.8,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,UKY 220 12/DC12,UKY22012DC12,6,1.83,39.3,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
@@ -2458,7 +3027,12 @@ ERICSSON,UKY 220 13/DC12 R3X,UKY22013DC12R3X,8,2.44,42.1,https://fccid.io/ANATEL
 ERICSSON,UKY 220 13/SC12,UKY22013SC12,8,2.44,42.1,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,UKY22013/SC12,UKY22013SC12,8,2.44,42.1,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
 ERICSSON,UKY22014/DC12,UKY22014DC12,10,3.05,43.5,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
+ERICSSON,UKY 220 14/DC12 R3X,UKY22014DC12R3X,10,3.05,43.2,Comsearch's Frequency Coordination Database
 ERICSSON,UKY 220 24/SC15,UKY22024SC15,3,0.91,33.9,https://fccid.io/ANATEL/01164-10-01882/Manual/6B919BD1-C385-4160-AEA5-A11D16F3B516/PDF
+ERICSSON,UKY 230 69/DC12,UKY23069DC12,8,2.44,42.2,Comsearch's Frequency Coordination Database
+ERICSSON,UKY 230 70/DC12,UKY23070DC12,10,3,43.2,Comsearch's Frequency Coordination Database
+RFS,UL6-W60A,UL6W60A,6,1.83,39.2,Comsearch's Frequency Coordination Database
+RFS,ULX6-W60A,ULX6W60A,6,1.83,39.2,Comsearch's Frequency Coordination Database
 ANDREW,UMX10-459,UMX10459,10,3.05,43.1,https://www.datasheet.directory/pdfviewer?url=https%3A%2F%2Fdatasheet.iiic.cc%2Fdatasheets-1%2Fandrew%2FUMX12-459.pdf
 COMMSCOPE,UMX10-459B,UMX10459B,10,3.05,43.1,Comsearch's Frequency Coordination Database
 Andrew Corporation,UMX10-611A LF,UMX10611ALF,10,3.05,42.2,https://worldradiohistory.com/Archive-Catalogs/Miscellaneous-Manufacturers/Andrew-Catalog-1997.pdf
@@ -2493,10 +3067,14 @@ GABRIEL,UOF8-64CSE LF,UOF864CSELF,8,2.44,41.8,Comsearch's Frequency Coordination
 GABRIEL,UOF8-64CSE LF,UOF864CSELF,8,2.44,41.8,Comsearch's Frequency Coordination Database
 GABRIEL,UOF8-64CSE RF,UOF864CSERF,8,2.44,41.8,Comsearch's Frequency Coordination Database
 GABRIEL,UOF8-64 LF,UOF864LF,8,2.44,41.9,Comsearch's Frequency Coordination Database
+ANDREW CORPORATION,UP8-59E,UP859E,8,2.44,41.3,Used UPX8-59E
 ANDREW,UPX8-59E,UPX859E,8,2.44,41.3,"Typo could be UHX or HPX, both have same gain, so using that. "
 COMMSCOPE,UPX8-59E,UPX859E,8,2.44,41.3,"Typo could be UHX or HPX, both have same gain, so using that. "
+COMMSCOPE,US10-6W,US106W,10,3.05,,Indeterminate. Band designator 6 unknown.
 GABRIEL,US10P-3J23C,US10P3J23C,10,3.05,43.1,Typo should be USR10P3J23C. Using that gain.
 RFS,USA6-757A,USA6757A,6,1.83,39,"Typo.  Should be this antenna, likely: https://www.rfsworld.com/pim/product/html/UXA6-U57AC"
+RFS,USA6-U57A,USA6U57A,6,1.83,39,Typo.  Should be https://www.rfsworld.com/pim/product/html/UXA6-U57AC
+RFS,USA8-U57A,USA8U57A,8,2.44,41.6,Assumed to be UXA8U57A
 GABRIEL,USR10P,USR10P,10,3.05,43.1,Comsearch's Frequency Coordination Database
 GABRIEL,USR10P-3J23C,USR10P3J23C,10,3.05,43.1,Comsearch's Frequency Coordination Database
 GABRIEL,USR10P-59,USR10P59,10,3.05,43.1,Comsearch's Frequency Coordination Database
@@ -2506,10 +3084,12 @@ GABRIEL,USR6P-59,USR6P59,6,1.83,38.6,Comsearch's Frequency Coordination Database
 GABRIEL,USR6P-59A,USR6P59A,6,1.83,38.6,Comsearch's Frequency Coordination Database
 GABRIEL,USR8P-3J23C,USR8P3J23C,8,2.44,41.1,Comsearch's Frequency Coordination Database
 GABRIEL,USR8P-59,USR8P59,8,2.44,41.1,Comsearch's Frequency Coordination Database
+COMMSCOPE,USX10-65E,USX1065E,10,3.05,,Indeterminate. Band designator 65 unknown. 
 ANDREW,USX10-6W,USX106W,10,3.05,43.2,https://www.commscope.com/globalassets/digizuite/261414-p360-usx10-6w-external.pdf
 COMMSCOPE,USX10-6W,USX106W,10,3.05,43.2,https://www.commscope.com/globalassets/digizuite/261414-p360-usx10-6w-external.pdf
 COMMSCOPE,USX10-6W-6GF,USX106W6GF,10,3.05,43.2,https://www.commscope.com/globalassets/digizuite/261414-p360-usx10-6w-external.pdf
 COMMSCOPE,USX12-6W,USX126W,12,3.66,45,Comsearch's Frequency Coordination Database
+COMMSCOPE,USX1.-6W,USX16W,,,,Indeterminate. Unknown diameter
 COMMSCOPE,USX4-59A RF,USX459ARF,4,1.22,34.4,"Typo could be HSX, using that gain.  "
 COMMSCOPE,USX6-59L RF,USX659LRF,6,1.83,38.8,Typo could be UHX using that gain. 
 ANDREW,USX6-6W,USX66W,6,1.83,38.8,https://www.commscope.com/globalassets/digizuite/261438-p360-usx6-6w-external.pdf
@@ -2517,16 +3097,19 @@ COMMSCOPE,USX6-6W,USX66W,6,1.83,38.8,https://www.commscope.com/globalassets/digi
 COMMSCOPE,USX6--6W,USX66W,6,1.83,38.8,https://www.commscope.com/globalassets/digizuite/261438-p360-usx6-6w-external.pdf
 COMMSCOPE,USX6-6W-6GR,USX66W6GR,6,1.83,38.8,https://www.commscope.com/globalassets/digizuite/261438-p360-usx6-6w-external.pdf
 RFS,USX-6W,USX6W,,,,No diameter available in the model so cannot discern proper gain
+CommScope,USX8-56W,USX856W,8,1.83,41.6,Typo should be USX8-6W
 ANDREW,USX8-62,USX862,8,2.44,42.4,https://www.commscope.com/globalassets/digizuite/261452-p360-usx8-6w-external.pdf
 ANDREW,USX8-6W,USX86W,8,2.44,41.6,https://www.commscope.com/globalassets/digizuite/261452-p360-usx8-6w-external.pdf
 COMMSCOPE,USX8-6W,USX86W,8,2.44,41.6,Comsearch's Frequency Coordination Database
 COMMSCOPE,USX8--6W,USX86W,8,2.44,41.6,Comsearch's Frequency Coordination Database
+Andrew Corporation,USX8-6W-6GF,USX86W6GF,8,2.44,41.6,Based on USX86W
 COMMSCOPE,USX8+8W,USX88W,8,2.44,,Indeterminate. Band designator 8 is not known. 
 COMMSCOPE,USX8-8W,USX88W,8,2.44,,Indeterminate. Band designator 8 is not known. 
 GABRIEL,UW8-5968 SE LF,UW85968SELF,8,2.44,41.6,Typo should be UWB85968SELF. Using that gain.
 GABRIEL,UWB10-5968SE LF,UWB105968SELF,10,3.05,43.5,Comsearch's Frequency Coordination Database
 GABRIEL,UWB10-5968SE RF,UWB105968SERF,10,3.05,43.5,Comsearch's Frequency Coordination Database
 GABRIEL,UWB10-5968(SS)RF,UWB105968SSRF,10,3.05,42.9,Comsearch's Frequency Coordination Database
+GABRIEL ELECTRONICS,UWB-5968 SE RF,UWB5968SERF,,,,Indeterminate. 
 GABRIEL,UWB6-5968SE RF,UWB65968SERF,6,1.83,39.1,Comsearch's Frequency Coordination Database
 GABRIEL,UWB6-5971SE LF,UWB65971SELF,6,1.83,38.7,Comsearch's Frequency Coordination Database
 GABRIEL,UWB6-5971SE RF,UWB65971SERF,6,1.83,38.7,Comsearch's Frequency Coordination Database
@@ -2537,6 +3120,7 @@ GABRIEL,UWB8-5968SE RF,UWB85968SERF,8,2.44,41.6,Comsearch's Frequency Coordinati
 GABRIEL,UWB8-5971A RF,UWB85971ARF,8,2.44,41.6,Comsearch's Frequency Coordination Database
 COMMSCOPE,UX10-59W,UX1059W,10,3.05,43.2,Typo should be UHX1059W. Using that gain. 
 COMMSCOPE,UX15-59H LF,UX1559HLF,15,4.57,46.4,Typo should be UHX1559HLF. Using that gain.
+RFS,UX16-W57A RF,UX16W57ARF,,,,Indeterminate. Diameter invalid.
 RFS,UX6-W59B LF,UX6W59BLF,6,1.83,39.1,"Typo, should be UXA6W59BLF.  Using that gain. "
 CABLEWAVE SYSTEMS,UXA10-59A,UXA1059A,10,3.05,43.2,https://www.rfsworld.com/pim/product/html/UXA10-59AD2
 RFS,UXA10-59A,UXA1059A,10,3.05,43.2,https://www.rfsworld.com/pim/product/html/UXA10-59AC
@@ -2589,13 +3173,14 @@ RFS,UXA12-W59 (P),UXA12W59P,12,3.66,45.1,https://www.rfsworld.com/pim/product/ht
 RFS,UXA4?59A,UXA459A,4,1.22,34.5,https://www.rfsworld.com/pim/product/html/UXA4-59AC
 RFS,UXA4-59A,UXA459A,4,1.22,34.5,https://www.rfsworld.com/pim/product/html/UXA4-59AC
 RFS,UXA4-65A LF,UXA465ALF,4,1.22,35.3,https://www.rfsworld.com/pim/product/html/UXA4-65AC
+RFS,UXA4-65A RF,UXA465ARF,4,1.22,35.3,Comsearch's Frequency Coordination Database
 RFS,UXA6-57A RF,UXA657ARF,6,1.83,,Indeterminate. 
 RFS,UXA6-59A,UXA659A,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 CABLEWAVE SYSTEMS,UXA6-59 AC LF,UXA659ACLF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59BD2H
 CABLEWAVE SYSTEMS,UXA6-59AC LF,UXA659ACLF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59BD2H
 CABLEWAVE SYSTEMS,UXA6-59A LF,UXA659ALF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59BD2H
-RFS,UXA6-59A LF,UXA659ALF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 CABLEWAVE SYSTEMS,UXA6-59A-LF,UXA659ALF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59BD2H
+RFS,UXA6-59A LF,UXA659ALF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 RFS,UXA6?¡59A RF,UXA659ARF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 RFS,UXA659A RF,UXA659ARF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 RFS,UXA6-59A RF,UXA659ARF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
@@ -2607,14 +3192,16 @@ RFS,UXA659C,UXA659C,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-5
 RFS,UXA6-59C,UXA659C,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 RFS,UXA6-59CC RF,UXA659CCRF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 RFS,UXA6-59C LF,UXA659CLF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
-RFS,UXA6?59C RF,UXA659CRF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
-RFS,UXA6?¡59C RF,UXA659CRF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
+RFS,UXA6-59C R,UXA659CR,6,1.83,38.7,Same as UXA6-59C RF
 COMMSCOPE,UXA6-59C RF,UXA659CRF,6,1.83,38.7,Comsearch's Frequency Coordination Database
+RFS,UXA6?¡59C RF,UXA659CRF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
+RFS,UXA6?59C RF,UXA659CRF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 RFS,UXA6-59C RF,UXA659CRF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 RFS,UXA6-59C-RF,UXA659CRF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
+RFS,UXA6-59C RF / 6.0 ft,UXA659CRF60FT,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 RFS,UXA6-59 L,UXA659L,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59CC
-RFS,UXA6-59 LF,UXA659LF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 Radio Frequency Systems,UXA6-59LF,UXA659LF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
+RFS,UXA6-59 LF,UXA659LF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 RFS,UXA6-59R,UXA659R,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 CABLEWAVE SYSTEMS,UXA6-59 RF,UXA659RF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59BD2H
 RFS,UXA6-59 RF,UXA659RF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
@@ -2622,8 +3209,8 @@ RFS,UXA6-59WAC RF,UXA659WACRF,6,1.83,38.7,https://alliancecorporation.ca/images/
 ANDREW,UXA6-59W LF,UXA659WLF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59CC
 RFS,UXA6-59W LF,UXA659WLF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59ACSQ1E
 CABLEWAVE SYSTEMS,UXA6-59W LF C43002,UXA659WLFC43002,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59BD2H
-CABLEWAVE SYSTEMS,UXA6-59W RF,UXA659WRF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59BD2H
 CABLEWAVE,UXA6-59W RF,UXA659WRF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59BD2H
+CABLEWAVE SYSTEMS,UXA6-59W RF,UXA659WRF,6,1.83,38.7,https://www.rfsworld.com/pim/product/html/UXA6-59BD2H
 RFS,UXA6-65A LF,UXA665ALF,6,1.83,39.7,https://www.rfsworld.com/pim/product/html/UXA6-65BC
 RFS,UXA6-65A RF,UXA665ARF,6,1.83,39.7,https://www.rfsworld.com/pim/product/html/UXA6-65BC
 RFS,UXA6-65B LF,UXA665BLF,6,1.83,39.7,https://www.rfsworld.com/pim/product/html/UXA6-65BC
@@ -2631,6 +3218,7 @@ RFS,UXA6-65B LF,UXA665BLF,6,1.83,39.7,https://www.rfsworld.com/pim/product/html/
 RFS,UXA6-65B RF,UXA665BRF,6,1.83,39.7,https://www.rfsworld.com/pim/product/html/UXA6-65BC
 RFS,UXA6-65B-RF,UXA665BRF,6,1.83,39.7,https://www.rfsworld.com/pim/product/html/UXA6-65BC
 RFS,UXA6-U57A,UXA6U57A,6,1.83,39,https://www.rfsworld.com/pim/product/html/UXA6-U57AC
+RFS,UXA6-U57AC,UXA6U57AC,6,1.83,39,https://www.rfsworld.com/pim/product/html/UXA6-U57AC
 RFS,UXA6-U57A LF,UXA6U57ALF,6,1.83,39,https://www.rfsworld.com/pim/product/html/UXA6-U57AC
 RFS,UXA6-U57A RF,UXA6U57ARF,6,1.83,39,https://www.rfsworld.com/pim/product/html/UXA6-U57AC
 RFS,UXA6-U57A RF,UXA6U57ARF,6,1.83,39,https://www.rfsworld.com/pim/product/html/UXA6-U57AC
@@ -2638,10 +3226,10 @@ RFS,UXA6W57A,UXA6W57A,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6
 RFS,UXA6-W57A,UXA6W57A,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
 RFS,UXA6-W57A LF,UXA6W57ALF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
 RFS,UXA6-W57A-LF,UXA6W57ALF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
-RFS,UXA6?W57A RF,UXA6W57ARF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
-RFS,UXA6?¡W57A RF,UXA6W57ARF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
-RFS,UXA6W57A RF,UXA6W57ARF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
 COMMSCOPE,UXA6-W57A RF,UXA6W57ARF,6,1.83,38.9,Comsearch's Frequency Coordination Database
+RFS,UXA6?¡W57A RF,UXA6W57ARF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
+RFS,UXA6?W57A RF,UXA6W57ARF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
+RFS,UXA6W57A RF,UXA6W57ARF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
 RFS,UXA6-W57A RF,UXA6W57ARF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
 RFS,UXA6-W57 RF,UXA6W57RF,6,1.83,38.9,https://www.rfsworld.com/pim/product/html/UXA6-W57AC
 RFS,UXA6-W59A,UXA6W59A,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/UXA6-W59ACSQ1E
@@ -2656,20 +3244,21 @@ RFS,UXA6?W59B RF,UXA6W59BRF,6,1.83,39.1,https://www.rfsworld.com/pim/product/htm
 RFS,UXA6W59B RF,UXA6W59BRF,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/UXA6-W59ACSQ1E
 RFS,UXA6-W59B RF,UXA6W59BRF,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/UXA6-W59ACSQ1E
 RFS,UXA6-W59B-RF,UXA6W59BRF,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/UXA6-W59ACSQ1E
+RFS,UXA6-W59B RF / 6.0 ft,UXA6W59BRF60FT,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/UXA6-W59ACSQ1E
 RFS,UXA6-W59C RF,UXA6W59CRF,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/UXA6-W59ACSQ1E
 RFS,UXA6-W59 RF,UXA6W59RF,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/UXA6-W59ACSQ1E
 RFS,UXA6-W9B RF,UXA6W9BRF,6,1.83,39.1,https://www.rfsworld.com/pim/product/html/UXA6-W59ACSQ1E
 CABLEWAVE SYSTEMS,UXA8059 RF S92250,UXA8059RFS92250,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC2
 RFS,UXA8-56A-RF,UXA856ARF,8,2.44,,Indeterminate. Band designator 56 unknown. 
-RFS,UXA 8 - 59A,UXA859A,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 CABLEWAVE SYSTEMS,UXA8-59A,UXA859A,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AD2H
+RFS,UXA 8 - 59A,UXA859A,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 RFS,UXA8-59A,UXA859A,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 Cablewave Systems,UXA8-59AC LF,UXA859ACLF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AD2H
 CABLEWAVE SYSTEMS,UXA8-59AC RF,UXA859ACRF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AD2H
 RFS,UXA8-59A LF,UXA859ALF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 RFS,UXA8-59A LF,UXA859ALF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
-RFS,UXA8-59A RF,UXA859ARF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 RADIO FREQUENCY SYSTEMS,UXA8-59A RF,UXA859ARF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
+RFS,UXA8-59A RF,UXA859ARF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 RFS,UXA8-59B,UXA859B,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 RFS,UXA8-59B LF,UXA859BLF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 COMMSCOPE,UXA8-59B RF,UXA859BRF,8,2.44,41.3,Comsearch's Frequency Coordination Database
@@ -2679,8 +3268,8 @@ CABLEWAVE SYSTEMS,UXA8-59LF,UXA859LF,8,2.44,41.3,https://www.rfsworld.com/pim/pr
 CABLEWAVE SYSTEMS,UXA8-59-LF,UXA859LF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AD2H
 CABLEWAVE SYSTEMS,UXA8 59 RF,UXA859RF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC2
 CABLEWAVE SYSTEMS,UXA8-59 RF,UXA859RF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AD2H
-RFS,UXA8-59 RF,UXA859RF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 CABLEWAVE SYSTEMS,UXA8-59RF,UXA859RF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AD2H
+RFS,UXA8-59 RF,UXA859RF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 CABLEWAVE SYSTEMS,UXA8-59 RF S92250,UXA859RFS92250,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AD2H
 RFS,UXA8-59W,UXA859W,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AC
 CABLEWAVE SYSTEMS,UXA8-59WAC RF,UXA859WACRF,8,2.44,41.3,https://www.rfsworld.com/pim/product/html/UXA8-59AD2H
@@ -2696,6 +3285,7 @@ RFS,UXA8-65a RF,UXA865ARF,8,2.44,42.2,https://www.rfsworld.com/pim/product/html/
 RFS,UXA8-65A-RF,UXA865ARF,8,2.44,42.2,https://www.rfsworld.com/pim/product/html/UXA8-65AC
 CABLEWAVE SYSTEMS,UXA8-65 LF,UXA865LF,8,2.44,42.5,https://www.rfsworld.com/pim/product/html/UXA8-65AD4
 CABLEWAVE SYSTEMS,UXA8-65 RF,UXA865RF,8,2.44,42.5,https://www.rfsworld.com/pim/product/html/UXA8-65AD4
+COMMSCOPE,UXA8-6W,UXA86W,,,,"UXA is an RFS prefix, not commscope, and -6W is not an RFS band suffix. "
 RFS,UXA8-U57,UXA8U57,8,2.44,41.6,https://www.rfsworld.com/pim/product/pdf/UXA8-U57AC
 RFS,UXA8-U57A,UXA8U57A,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-U57AC
 RFS,UXA8-U57AC,UXA8U57AC,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-U57AC
@@ -2710,14 +3300,18 @@ RFS,UXA8-W57A RF,UXA8W57ARF,8,2.44,41.4,https://www.rfsworld.com/pim/product/htm
 RFS,UXA8-W57A RF,UXA8W57ARF,8,2.44,41.4,https://www.rfsworld.com/pim/product/html/UXA8-W57AC
 RFS,UXA8-W59A,UXA8W59A,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-W59AC
 RFS,UXA8-W59AC,UXA8W59AC,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-W59AC
+RFS,UXA8-W59AC-RF,UXA8W59ACRF,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-W59AC
 RFS,UXA8-W59A LF,UXA8W59ALF,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-W59AC
 RFS,UXA8-W59A-LF,UXA8W59ALF,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-W59AC
-RFS,UXA8-W59A (RF),UXA8W59ARF,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-W59AC
 COMMSCOPE,UXA8-W59A RF,UXA8W59ARF,8,2.44,41.6,Comsearch's Frequency Coordination Database
+RFS,UXA8-W59A (RF),UXA8W59ARF,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-W59AC
 RFS,UXA8-W59A RF,UXA8W59ARF,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-W59AC
 RFS,UXA8-W59A-RF,UXA8W59ARF,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-W59AC
 RFS,UXA8-WA59A RF,UXA8WA59ARF,8,2.44,41.6,https://www.rfsworld.com/pim/product/html/UXA8-W59AC
 RFS,UXA8-WF9A RF,UXA8WF9ARF,8,2.44,41.6,Typo should be UXA8W59ARF. Using that gain. 
+RFS,UXAG-W59B RF,UXAGW59BRF,,,,Indeterminate. 
+RFS,UXA-W57A RF,UXAW57ARF,,,,Indeterminate. 
+RFS,UXA-W59A RF,UXAW59ARF,,,,Indeterminate. 
 COMMSCOPE,UXH10-59J RF,UXH1059JRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UXH10-59K RF,UXH1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UXH12-59E LF,UXH1259ELF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
@@ -2725,8 +3319,12 @@ COMMSCOPE,UXH6-59L RF,UXH659LRF,6,1.83,38.8,Typo should be UHX659LRF. Using that
 ANDREW,UXH8-59H,UXH859H,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,UXH8-59H LF,UXH859HLF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,UXH8-59J RF,UXH859JRF,8,2.44,41.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Commscope,UXS8-6W,UXS86W,8,2.44,41.6,Typo should be USX8-6W
+RFS,V,V,,,,Indeterminate.
+NOKIA,VCE67-L3-1024A30S-230,VCE67L31024A30S230,,,,Radio - Indeterminate. 
 ANDREW,VHLP3-6W,VHLP36W,3,0.91,33.3,https://www.commscope.com/globalassets/digizuite/471591-p360-vhlp3-6w-a-external.pdf
 ANDREW,VHLP3-6W-4WH,VHLP36W4WH,3,0.91,33.3,https://www.commscope.com/globalassets/digizuite/471588-p360-vhlp3-6w-6wh-a-external.pdf
+Commscope,VHLP3-6W-6WH/A,VHLP36W6WHA,3,0.91,33.3,Based on VHLP36W
 ANDREW,VHLP3-6WA,VHLP36WA,3,0.91,33.3,https://www.commscope.com/globalassets/digizuite/471591-p360-vhlp3-6w-a-external.pdf
 ANDREW,VHLP4-6W,VHLP46W,4,1.22,35,Comsearch's Frequency Coordination Database
 COMMSCOPE,VHLP4-6W,VHLP46W,4,1.22,35,Comsearch's Frequency Coordination Database
@@ -2735,9 +3333,13 @@ COMMSCOPE,VHLP4-6W/B,VHLP46WB,4,1.22,35,Comsearch's Frequency Coordination Datab
 COMMSCOPE,VHLP4-6WB,VHLP46WB,4,1.22,35,Comsearch's Frequency Coordination Database
 ANDREW,VHLP4-6W/C,VHLP46WC,4,1.22,35.5,https://www.commscope.com/globalassets/digizuite/471694-p360-vhlp4-6w-c-external.pdf
 COMMSCOPE,VHLP4-6WC,VHLP46WC,4,1.22,35.5,https://www.commscope.com/globalassets/digizuite/471694-p360-vhlp4-6w-c-external.pdf
+Commscope,VHLP4-6W-GT1,VHLP46WGT1,4,1.22,35,Comsearch's Frequency Coordination Database
+ANDREW,VHLP6,VHLP6,6,1.83,,Band indeterminate
+COMMSCOPE,VHLP6-5WB,VHLP65WB,6,1.83,39.3,Typo should be VHLP6-6WB
 ANDREW,VHLP6-6W,VHLP66W,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
 COMMSCOPE,VHLP6-6W,VHLP66W,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
 ANDREW,VHLP6-6W-4GR/A,VHLP66W4GRA,6,1.83,39,https://objects.eanixter.com/PD357641.PDF
+Commscope,VHLP6-6W-6WH/B,VHLP66W6WHB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
 ANDREW,VHLP6-6W/A,VHLP66WA,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
 ANDREW,VHLP6-6WA,VHLP66WA,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
 COMMSCOPE,VHLP6-6WA,VHLP66WA,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
@@ -2749,34 +3351,44 @@ COMMSCOPE,VHLP6-6WB,VHLP66WB,6,1.83,39.3,Comsearch's Frequency Coordination Data
 COMMSCOPE,vhlp6-6wb,VHLP66WB,6,1.83,39.3,Comsearch's Frequency Coordination Database
 ANDREW,VHLP6-6WB (CAT A),VHLP66WBCATA,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
 COMMSCOPE,VHLP6-6WB (CAT A),VHLP66WBCATA,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
+Commscope,VHLP6-6WC,VHLP66WC,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
+Commscope,VHLP6-6W-CR5C,VHLP66WCR5C,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
 ANDREW,VHLP6-6W-SE1B,VHLP66WSE1B,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
 COMMSCOPE,VHLP6-WA,VHLP6WA,6,1.83,,No band indicated in model so cannot determine gain. 
 COMMSCOPE,VHLP6-^WB,VHLP6WB,6,1.83,,No band indicated in model so cannot determine gain. 
 COMMSCOPE,VHLPA4-6WB80.2,VHLPA46WB802,4,1.22,35,Typo should be VHLP46WB
+COMMSCOPE,VHLPA6-6WB,VHLPA66WB,6,1.83,39.3,Typo should be VHLP6-6WB
 ANDREW,VHLPX3-6W,VHLPX36W,3,0.91,33.3,https://www.commscope.com/globalassets/digizuite/472015-p360-vhlpx3-6w-a-external.pdf
-Commscope,VHLPX3-6WA,VHLPX36WA,3,1.22,33.3,https://www.commscope.com/globalassets/digizuite/472015-p360-vhlpx3-6w-a-external.pdf
-COMMSCOPE,VHLPX4?6W,VHLPX46W,4,1.22,35,Comsearch's Frequency Coordination Database
+Commscope,VHLPX3-6WA,VHLPX36WA,3,0.91,33.3,https://www.commscope.com/globalassets/digizuite/472015-p360-vhlpx3-6w-a-external.pdf
 ANDREW,VHLPX4-6W,VHLPX46W,4,1.22,35,Comsearch's Frequency Coordination Database
+COMMSCOPE,VHLPX4?6W,VHLPX46W,4,1.22,35,Comsearch's Frequency Coordination Database
 COMMSCOPE,VHLPX4-6W,VHLPX46W,4,1.22,35,Comsearch's Frequency Coordination Database
 ANDREW,VHLPX4-6W-6WH/C,VHLPX46W6WHC,4,1.22,35,Comsearch's Frequency Coordination Database
 COMMSCOPE,VHLPX4-6W-6WH/C,VHLPX46W6WHC,4,1.22,35,Comsearch's Frequency Coordination Database
 ANDREW,VHLPX4-6WB,VHLPX46WB,4,1.22,35,Comsearch's Frequency Coordination Database
 COMMSCOPE,VHLPX4-6WB,VHLPX46WB,4,1.22,35,Comsearch's Frequency Coordination Database
-COMMSCOPE,VHLPX4?¡6WC,VHLPX46WC,4,1.22,35.5,Comsearch's Frequency Coordination Database
 ANDREW,VHLPX4-6W/C,VHLPX46WC,4,1.22,35.5,Comsearch's Frequency Coordination Database
+COMMSCOPE,VHLPX4?¡6WC,VHLPX46WC,4,1.22,35.5,Comsearch's Frequency Coordination Database
 COMMSCOPE,VHLPX4-6WC,VHLPX46WC,4,1.22,35.5,Comsearch's Frequency Coordination Database
 ANDREW,VHLPX606W,VHLPX606W,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
 ANDREW,VHLPX6-6W,VHLPX66W,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
 COMMSCOPE,VHLPX6-6W,VHLPX66W,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
 ANDREW,VHLPX6-6W-6WH/A,VHLPX66W6WHA,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472149-p360-vhlpx6-6w-6wh-b-external.pdf
 COMMSCOPE,VHLPX6-6W-6WH/A,VHLPX66W6WHA,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
+Commscope,VHLPX6-6W-6WH/B,VHLPX66W6WHB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
 COMMSCOPE,VHLPX6-6WA,VHLPX66WA,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
+Commscope,VHLPX66WA((AT B),VHLPX66WAATB,6,1.83,39,Assumed to be VHLP66WACATB
 COMMSCOPE,VHLPX6-6WA (CAT B ),VHLPX66WACATB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
 COMMSCOPE,VHLPX6-6WA (CAT B),VHLPX66WACATB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
+ANDREW,VHLPX6-6WB,VHLPX66WB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
 COMMSCOPE,VHLPX6?¡6WB,VHLPX66WB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
 Commscope,VHLPX66WB,VHLPX66WB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
-ANDREW,VHLPX6-6WB,VHLPX66WB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
 COMMSCOPE,VHLPX6-6WB,VHLPX66WB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
+Commscope,VHLPX6-6WC,VHLPX66WC,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
+COMMSCOPE,VHLPX6-6WN,VHLPX66WN,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
+COMMSCOPE,VHLPX6-WB,VHLPX6WB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/472152-p360-vhlpx6-6w-b-external.pdf
+CommScope,VHLPXX4-6WC,VHLPXX46WC,4,1.22,35.5,Typo should be VHLPX4-6WC
+CommScope,VHP3-6W,VHP36W,3,0.91,33.3,Assumed to be VHLP36W
 ANDREW,VHP4-107,VHP4107,,,,Model does not belong in this band.
 ANDREW,VHP4-107A,VHP4107A,,,,Model does not belong in this band.
 ANDREW,VHP6-107,VHP6107,,,,Model does not belong in this band.
@@ -2786,24 +3398,74 @@ COMMSCOPE,VHPX12-6W,VHPX126W,12,3.66,45.4,Comsearch's Frequency Coordination Dat
 COMMSCOPE,VHPX8-6W,VHPX86W,8,2.44,42.1,Comsearch's Frequency Coordination Database
 <KLQB-FM>,<VLHP6-6WB>,VLHP66WB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
 COMMSCOPE,VLHP6-6WB,VLHP66WB,6,1.83,39.3,https://www.commscope.com/globalassets/digizuite/471777-p360-vhlp6-6w-b-external.pdf
+NEC AMERICA,VR HPT+AV_L6G-2048Q-30M,VRHPTAVL6G2048Q30M,,,,Radio - Indeterminate. 
+NEC AMERICA,VR HPT+AV_U6G-2048Q-30M,VRHPTAVU6G2048Q30M,,,,Radio - Indeterminate. 
+NOKIA,vWVCE61-L3-1024A30S-230,VWVCE61L31024A30S230,,,,Radio - Indeterminate. 
+Nokia,WCE61-L2-1024A30S-230,WCE61L21024A30S230,,,,Radio - Indeterminate. 
 COMMSCOPE,WEHP6-59K,WEHP659K,6,1.83,38.9,Comsearch's Frequency Coordination Database
 COMMSCOPE,WEUHX10-59K RF,WEUHX1059KRF,10,3.05,43.2,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,WHP6-59J,WHP659J,6,1.83,38.9,Comsearch's Frequency Coordination Database
 COMMSCOPE,WHP6-59WC,WHP659WC,6,1.83,39.4,Comsearch's Frequency Coordination Database
 ANDREW,WHP8-59F,WHP859F,8,2.44,41.5,Comsearch's Frequency Coordination Database
 COMMSCOPE,WHP8-59F,WHP859F,8,2.44,41.5,Comsearch's Frequency Coordination Database
+Commscope,WHP8-65F,WHP865F,8,2.44,42.3,Comsearch's Frequency Coordination Database
 ANDREW,WPAR6-59B,WPAR659B,6,1.83,38.2,Comsearch's Frequency Coordination Database
 COMMSCOPE,WPAR6-59B,WPAR659B,6,1.83,38.2,Comsearch's Frequency Coordination Database
 COMMSCOPE,WPAR6-59WA RF,WPAR659WARF,6,1.83,38.7,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 ANDREW,WPAR6-65B RF,WPAR665BRF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 ANDREW,WPAR8-59A,WPAR859A,8,2.44,40.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,WPAR8-59A,WPAR859A,8,2.44,40.8,Comsearch's Frequency Coordination Database
+Commscope,WPAR8-65A RF,WPAR865ARF,8,2.44,41.3,Comsearch's Frequency Coordination Database
+COMMSCOPE,WRUQ634,WRUQ634,,,,Call Sign - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-30M,WT41L630M,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M,WT41L660M,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M 1024Q 462MB,WT41L660M1024Q462MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M 128Q 313MB,WT41L660M128Q313MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M 16Q 181MB,WT41L660M16Q181MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M 2048Q 506MB,WT41L660M2048Q506MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M 256Q 357MB,WT41L660M256Q357MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M 32Q 212MB,WT41L660M32Q212MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M 4096Q 546MB,WT41L660M4096Q546MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M 512Q 408MB,WT41L660M512Q408MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M 64Q 265MB,WT41L660M64Q265MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-L6-60M QPSK 77MB,WT41L660MQPSK77MB,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT41-U6-10M 2048Q 81MB,WT41U610M2048Q81MB,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,WT41_U6_30M_272 ACM,WT41U630M272ACM,,,,Radio - Indeterminate. 
+Aviat Networks,WT42_6_30M_ACM,WT42630MACM,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT42O-L6-60M,WT42OL660M,,,,Radio - Indeterminate. 
+"Aviat Networks, Inc.",WT45-L6-30M 4096Q 272MB,WT45L630M4096Q272MB,,,,Radio - Indeterminate. 
+AVIAT NETWORKS,WT45_L6_60M_546 ACM,WT45L660M546ACM,,,,Radio - Indeterminate. 
 COMMSCOPE,WUHP6-59WB RF,WUHP659WBRF,6,1.83,39.3,Comsearch's Frequency Coordination Database
 COMMSCOPE,WUHX12-59W RF,WUHX1259WRF,12,3.66,44.8,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
 COMMSCOPE,WUHX15-59H RF,WUHX1559HRF,15,4.57,46.4,Comsearch's Frequency Coordination Database
+Commscope,WUHX6-59B,WUHX659B,6,1.83,38.8,Comsearch: all WUHX6-59 have same spec
 COMMSCOPE,WUHX6-59L LF,WUHX659LLF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,WUHX6-59L RF,WUHX659LRF,6,1.83,38.8,Comsearch's Frequency Coordination Database
+Commscope,WUHX6-59WB,WUHX659WB,6,1.83,38.8,Comsearch: all WUHX6-59 have same spec
 COMMSCOPE,WUHX6-59WB RF,WUHX659WBRF,6,1.83,38.8,Comsearch's Frequency Coordination Database
 COMMSCOPE,WUHX8-59J RF,WUHX859JRF,8,2.44,41.3,https://www.digchip.com/datasheets/parts/datasheet/3751/HP12-59E-pdf.php
+Nokia,WVCE61-J,WVCE61J,,,,Radio - Indeterminate. 
+Nokia,WVCE61-J-1024A60S-435 HP,WVCE61J1024A60S435HP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-J-128A60S-308 HP,WVCE61J128A60S308HP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-J-16A60S-161 HP,WVCE61J16A60S161HP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-J-2048A60S-485 HP,WVCE61J2048A60S485HP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-J-256A60S-350 HP,WVCE61J256A60S350HP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-J-32A60S-201 HP,WVCE61J32A60S201HP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-J-4096A60S-513 HP,WVCE61J4096A60S513HP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-J-4A60S-81 HP,WVCE61J4A60S81HP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-J-512A60S-396 HP,WVCE61J512A60S396HP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-J-64A60S-259 HP,WVCE61J64A60S259HP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-U,WVCE61U,,,,Radio - Indeterminate. 
+Nokia,WVCE61-U-1024A30S-236 XP,WVCE61U1024A30S236XP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-U-128A30S-168 XP,WVCE61U128A30S168XP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-U-16A30S-91 XP,WVCE61U16A30S91XP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-U2,WVCE61U2,,,,Radio - Indeterminate. 
+Nokia,WVCE61-U-256A30S-189 XP,WVCE61U256A30S189XP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-U-32A30S-114 XP,WVCE61U32A30S114XP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-U-4A30S-45 XP,WVCE61U4A30S45XP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-U-512A30S-212 XP,WVCE61U512A30S212XP,,,,Radio - Indeterminate. 
+Nokia,WVCE61-U-64A30S-142 XP,WVCE61U64A30S142XP,,,,Radio - Indeterminate. 
+NOKIA,WVCE-L2-1024A10S,WVCEL21024A10S,,,,Radio - Indeterminate. 
+NOKIA,WVE67-L2-1024A10S-73,WVE67L21024A10S73,,,,Radio - Indeterminate. 
 RFS,WXA6-W57A RF,WXA6W57ARF,6,1.83,38.9,Typo should be UXA6W57ARF. Using that gain
 RFS,WXA8-W57A RF,WXA8W57ARF,8,2.44,41.4,Typo should be UXA8W57ARF. Using that gain. 


### PR DESCRIPTION
This PR includes several updates to the antenna model, diameter, gain dataset stored in the common_data folder.

Additionally, this PR revised the README for the common_data folder to include links to previously published versions of the data within this folder.