### PR TITLE
Fixes to Request Validator permitted ranges

### DIFF
--- a/src/harness/request_validator.py
+++ b/src/harness/request_validator.py
@@ -318,7 +318,7 @@ class InquiryRequestValidator(sdi_validate.SDIValidatorBase):
       is_valid = False
       self._warning(f'Length ({vector.length}) must be a single finite numeric value')
 
-    # angle is a valid number in the range [-90, 90]
+    # angle is a valid number in the range [0, 360]
     try:
       if not (0 <= vector.angle <= 360):
         raise TypeError()

--- a/src/harness/request_validator.py
+++ b/src/harness/request_validator.py
@@ -361,7 +361,7 @@ class InquiryRequestValidator(sdi_validate.SDIValidatorBase):
 
     # verticalUncertainty is a valid, positive, finite integer
     try:
-      if not (0 <= elev.verticalUncertainty):
+      if not (0 < elev.verticalUncertainty):
         raise TypeError()
     except TypeError:
       is_valid = False
@@ -526,7 +526,7 @@ class InquiryRequestValidator(sdi_validate.SDIValidatorBase):
 
     # majorAxis is a valid, positive integer
     try:
-      if not (0 <= ellipse.majorAxis):
+      if not (0 < ellipse.majorAxis):
         raise TypeError()
     except TypeError:
       is_valid = False
@@ -534,7 +534,7 @@ class InquiryRequestValidator(sdi_validate.SDIValidatorBase):
 
     # minorAxis is a valid, positive integer
     try:
-      if not (0 <= ellipse.minorAxis):
+      if not (0 < ellipse.minorAxis):
         raise TypeError()
     except TypeError:
       is_valid = False


### PR DESCRIPTION
Fixes #75 by excluding 0 from the permitted values of majorAxis and minorAxis in the request validator. Also makes the same correction to the verticalUncertainty field, which should also strictly be a positive integer greater than 0 per the WFA SDI specification.

This PR also corrects a minor error in the commented range for the vector class's angle field in the request validator.